### PR TITLE
Interface clean up

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
@@ -82,6 +82,7 @@ public class LogstashBuildWrapper extends BuildWrapper {
       } catch (IOException e1) {
         e.printStackTrace();
       }
+
     }
 
     BuildData buildData = new BuildData(build, new Date());
@@ -96,11 +97,11 @@ public class LogstashBuildWrapper extends BuildWrapper {
   }
 
   // Method to encapsulate calls to Jenkins.getInstance() for unit-testing
-  protected LogstashIndexerDao getDao() throws InstantiationException {
+  LogstashIndexerDao getDao() throws InstantiationException {
     return LogstashInstallation.getLogstashDescriptor().getIndexerDao();
   }
 
-  protected String getJenkinsUrl() {
+  String getJenkinsUrl() {
     return Jenkins.getInstance().getRootUrl();
   }
 

--- a/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
@@ -65,7 +65,7 @@ public class LogstashInstallation extends ToolInstallation {
   public static final class Descriptor extends ToolDescriptor<LogstashInstallation> {
     public IndexerType type;
     public String host;
-    public Integer port;
+    public Integer port = -1;
     public String username;
     public String password;
     public String key;
@@ -95,13 +95,9 @@ public class LogstashInstallation extends ToolInstallation {
     }
 
     /**
-     * @see IndexerDaoFactory#getInstance(IndexerType, String, int, String, String)
+     * @see IndexerDaoFactory#getInstance(IndexerType, String, Integer, String, String, String)
      */
     public LogstashIndexerDao getIndexerDao() throws InstantiationException {
-      if (StringUtils.isEmpty(host)) {
-        return null;
-      }
-
       return IndexerDaoFactory.getInstance(type, host, port, key, username, password);
     }
 

--- a/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
@@ -106,12 +106,14 @@ public class LogstashNotifier extends Notifier {
 
     BuildData buildData = new BuildData(build, new Date());
     JSONObject payload = dao.buildPayload(buildData, jenkinsUrl, logLines);
-    long result = dao.push(payload.toString(), listener.getLogger());
-    if (result < 0) {
-      listener.getLogger().println("[logstash-plugin]: Failed to send log data to " + dao.getIndexerType() + ":" + dao.getHost() + ":" + dao.getPort() + ".");
+
+    try {
+      dao.push(payload.toString());
+    } catch (IOException e) {
+      listener.getLogger().println("[logstash-plugin]: Failed to send log data to " + dao.getIndexerType() + ":" + dao.getHost() + ":" + dao.getPort() + ".\n" +
+        ExceptionUtils.getStackTrace(e));
       return !failBuild;
     }
-
     return true;
   }
 

--- a/src/main/java/jenkins/plugins/logstash/LogstashOutputStream.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashOutputStream.java
@@ -45,11 +45,11 @@ import org.apache.commons.lang.exception.ExceptionUtils;
  */
 public class LogstashOutputStream extends PlainTextConsoleOutputStream {
 
-  protected OutputStream delegate;
-  protected LogstashIndexerDao dao;
-  protected BuildData buildData;
-  protected String jenkinsUrl;
-  protected boolean connFailed = false;
+  final OutputStream delegate;
+  final LogstashIndexerDao dao;
+  final BuildData buildData;
+  final String jenkinsUrl;
+  Boolean connFailed = false;
 
   public LogstashOutputStream(OutputStream delegate, LogstashIndexerDao dao, BuildData buildData, String jenkinsUrl) {
     super(delegate);
@@ -59,7 +59,9 @@ public class LogstashOutputStream extends PlainTextConsoleOutputStream {
     this.jenkinsUrl = jenkinsUrl;
 
     if (dao == null) {
-      String msg = "[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n";
+      connFailed = true;
+      String msg = "[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n" +
+        "[logstash-plugin]: No Further logs will be sent.\n";
 
       try {
         delegate.write(msg.getBytes());
@@ -74,18 +76,22 @@ public class LogstashOutputStream extends PlainTextConsoleOutputStream {
     delegate.write(b, 0, len);
     delegate.flush();
 
+    if (connFailed) {
+      return;
+    }
+
     String line = new String(b, 0, len).trim();
     line = ConsoleNote.removeNotes(line);
 
-    if (!line.isEmpty() && dao != null && !connFailed) {
+    if (!line.isEmpty()) {
       JSONObject payload = dao.buildPayload(buildData, jenkinsUrl, Arrays.asList(line));
       try {
         dao.push(payload.toString());
       } catch (IOException e) {
-        String msg = "[logstash-plugin]: Failed to send log data to " + dao.getIndexerType() + ":" + dao.getHost() + ":" + dao.getPort() + ".\n" +
+        connFailed = true;
+        String msg = "[logstash-plugin]: Failed to send log data to " + dao.getIndexerType() + ":" + dao.getDescription() + ".\n" +
           "[logstash-plugin]: No Further logs will be sent.\n" +
           ExceptionUtils.getStackTrace(e);
-        connFailed = true;
         delegate.write(msg.getBytes());
         delegate.flush();
       }

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -69,12 +69,7 @@ abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
   }
 
   @Override
-  public String getHost() {
-    return host;
-  }
-
-  @Override
-  public int getPort() {
-    return port;
+  public String getDescription() {
+    return this.host + ":" + this.port;
   }
 }

--- a/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
@@ -88,17 +88,6 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
     clientBuilder = factory == null ? HttpClientBuilder.create() : factory;
   }
 
-  @Override
-  public long push(String data, PrintStream logger) {
-    try {
-      this.push(data);
-      return 1;
-    } catch (IOException e) {
-      logger.println(ExceptionUtils.getStackTrace(e));
-    }
-    return -1;
-  }
-
   HttpPost getHttpPost(String data) {
     HttpPost postRequest;
     postRequest = new HttpPost(uri);
@@ -110,7 +99,8 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
     return postRequest;
   }
 
-  private void push(String data) throws IOException {
+  @Override
+  public void push(String data) throws IOException {
     CloseableHttpClient httpClient = null;
     CloseableHttpResponse response = null;
     HttpPost post = getHttpPost(data);

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
@@ -24,7 +24,7 @@
 
 package jenkins.plugins.logstash.persistence;
 
-import java.io.PrintStream;
+import java.io.IOException;
 import java.util.List;
 
 import net.sf.json.JSONObject;
@@ -53,11 +53,10 @@ public interface LogstashIndexerDao {
    *
    * @param data
    *          The serialized data, not null
-   * @param logger
-   *          A logger to append messages to, not null
-   * @return The number of elements pushed, -1 indicates an error occurred
+   * @throws java.io.IOException
+   *          The data is not written to the server
    */
-  long push(String data, PrintStream logger);
+  void push(String data) throws IOException;
 
   /**
    * Builds a JSON payload compatible with the Logstash schema.

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
@@ -42,9 +42,7 @@ public interface LogstashIndexerDao {
     ELASTICSEARCH
   }
 
-  int getPort();
-
-  String getHost();
+  String getDescription();
 
   IndexerType getIndexerType();
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
@@ -25,10 +25,8 @@
 package jenkins.plugins.logstash.persistence;
 
 import java.io.IOException;
-import java.io.PrintStream;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
@@ -70,7 +68,7 @@ public class RabbitMqDao extends AbstractLogstashIndexerDao {
   }
 
   @Override
-  public long push(String data, PrintStream logger) {
+  public void push(String data) throws IOException {
     Connection connection = null;
     Channel channel = null;
     try {
@@ -79,16 +77,14 @@ public class RabbitMqDao extends AbstractLogstashIndexerDao {
 
       channel.queueDeclare(key, true, false, false, null);
       channel.basicPublish("", key, null, data.getBytes());
-
-      channel.close();
-      connection.close();
-
-      return 1;
-    } catch (IOException e) {
-      logger.println(ExceptionUtils.getStackTrace(e));
+    } finally {
+      if (channel != null) {
+        channel.close();
+      }
+      if (connection != null) {
+        connection.close();
+      }
     }
-
-    return -1;
   }
 
   @Override

--- a/src/test/java/jenkins/plugins/logstash/LogstashBuildWrapperTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashBuildWrapperTest.java
@@ -1,10 +1,10 @@
 package jenkins.plugins.logstash;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.core.StringContains.containsString;
+
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.model.Project;
@@ -38,12 +38,16 @@ public class LogstashBuildWrapperTest {
     }
 
     @Override
-    protected LogstashIndexerDao getDao() {
+    LogstashIndexerDao getDao() throws InstantiationException {
+      if (dao == null) {
+        throw new InstantiationException("DoaTestInstantiationException");
+      }
+
       return dao;
     }
 
     @Override
-    public String getJenkinsUrl() {
+    String getJenkinsUrl() {
       return "http://my-jenkins-url";
     }
   }
@@ -70,8 +74,7 @@ public class LogstashBuildWrapperTest {
     when(mockProject.getName()).thenReturn("LogstashNotifierTest");
 
     when(mockDao.getIndexerType()).thenReturn(IndexerType.REDIS);
-    when(mockDao.getHost()).thenReturn("localhost");
-    when(mockDao.getPort()).thenReturn(8080);
+    when(mockDao.getDescription()).thenReturn("localhost:8080");
 
     buffer = new ByteArrayOutputStream();
   }
@@ -104,6 +107,6 @@ public class LogstashBuildWrapperTest {
     // Verify results
     assertNotNull("Result was null", result);
     assertTrue("Result is not the right type", result instanceof LogstashOutputStream);
-    assertEquals("Results don't match", "[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n", buffer.toString());
+    assertThat("Results don't match", buffer.toString(), containsString("[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n[logstash-plugin]: No Further logs will be sent.\n"));
   }
 }

--- a/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 
 import jenkins.plugins.logstash.persistence.BuildData;
 import jenkins.plugins.logstash.persistence.LogstashIndexerDao;
@@ -19,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @SuppressWarnings("resource")
@@ -31,9 +31,9 @@ public class LogstashOutputStreamTest {
   @Mock BuildData mockBuildData;
 
   @Before
-  public void before() {
+  public void before() throws Exception {
     when(mockDao.buildPayload(Matchers.any(BuildData.class), Matchers.anyString(), Matchers.anyListOf(String.class))).thenReturn(new JSONObject());
-    when(mockDao.push(Matchers.startsWith("{}"), Matchers.any(PrintStream.class))).thenReturn(1L);
+    Mockito.doNothing().when(mockDao).push(Matchers.startsWith("{}"));
     when(mockDao.getIndexerType()).thenReturn(IndexerType.REDIS);
     when(mockDao.getHost()).thenReturn("localhost");
     when(mockDao.getPort()).thenReturn(8080);
@@ -78,7 +78,7 @@ public class LogstashOutputStreamTest {
     assertEquals("Results don't match", msg, buffer.toString());
 
     verify(mockDao).buildPayload(Matchers.eq(mockBuildData), Matchers.eq("http://my-jenkins-url"), Matchers.anyListOf(String.class));
-    verify(mockDao).push(Matchers.eq("{}"), Matchers.any(PrintStream.class));
+    verify(mockDao).push("{}");
   }
 
   @Test

--- a/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
@@ -35,8 +35,7 @@ public class LogstashOutputStreamTest {
     when(mockDao.buildPayload(Matchers.any(BuildData.class), Matchers.anyString(), Matchers.anyListOf(String.class))).thenReturn(new JSONObject());
     Mockito.doNothing().when(mockDao).push(Matchers.startsWith("{}"));
     when(mockDao.getIndexerType()).thenReturn(IndexerType.REDIS);
-    when(mockDao.getHost()).thenReturn("localhost");
-    when(mockDao.getPort()).thenReturn(8080);
+    when(mockDao.getDescription()).thenReturn("localhost:8080");
 
     buffer = new ByteArrayOutputStream();
   }
@@ -62,7 +61,7 @@ public class LogstashOutputStreamTest {
     new LogstashOutputStream(buffer, null, mockBuildData, "http://my-jenkins-url");
 
     // Verify results
-    assertEquals("Results don't match", "[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n", buffer.toString());
+    assertEquals("Results don't match", "[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n[logstash-plugin]: No Further logs will be sent.\n", buffer.toString());
   }
 
   @Test

--- a/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
@@ -3,7 +3,7 @@ package jenkins.plugins.logstash.persistence;
 import static net.sf.json.test.JSONAssert.assertEquals;
 import static org.mockito.Mockito.when;
 
-import java.io.PrintStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -69,9 +69,7 @@ public class AbstractLogstashIndexerDaoTest {
         return IndexerType.REDIS;
       }
 
-      public long push(String data, PrintStream logger) {
-        return 0;
-      }
+      public void push(String data) throws IOException {}
     };
   }
 }

--- a/src/test/java/jenkins/plugins/logstash/persistence/IndexerDaoFactoryTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/IndexerDaoFactoryTest.java
@@ -18,4 +18,26 @@ public class IndexerDaoFactoryTest {
       assertEquals("Result implements wrong IndexerType", type, dao.getIndexerType());
     }
   }
+
+  @Test
+  public void successNulls() throws Exception {
+    for (IndexerType type : IndexerType.values()) {
+      String host = type == IndexerType.ELASTICSEARCH ? "http://localhost" : "localhost";
+      LogstashIndexerDao dao = IndexerDaoFactory.getInstance(type, host, null, "key", null, null);
+
+      assertNotNull("Result was null", dao);
+      assertEquals("Result implements wrong IndexerType", type, dao.getIndexerType());
+    }
+  }
+
+  @Test(expected = InstantiationException.class)
+  public void failureNullType() throws Exception {
+    try {
+      IndexerDaoFactory.getInstance(null, "localhost", 1234, "key", "username", "password");
+    } catch (InstantiationException e) {
+      String msg = "[logstash-plugin]: Unknown IndexerType 'null'. Did you forget to configure the plugin?";
+      assertEquals("Wrong message", msg, e.getMessage());
+      throw e;
+    }
+  }
 }


### PR DESCRIPTION
There were a number of tweaks to the interface that seemed sensible to me.  If you want I can break them out into separate pull requests, but they can get a tedious. 

Overview:
 * dao.push() should not log status. It should either succeed or throw, nothing else.   Status logging (if any) should be handled by the wrapper, notifier, or stream. 
 * dao.getDescription() - instead of handing out the port and host, what we really want is to let the dao give us a description of its settings in a format that is meaningful to it. 
 * `final` and package private - most of the uses of `protected` don't need to be there.  Many fields are assigned once and should communicate that by being `final`. 
 * disallow null where possible - there was a path for getDao() that checked the host value and returned null.  That is the responsibility of the constructor and it should throw.