### PR TITLE
Feature jms with ActiveMQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
   <artifactId>logstash</artifactId>
   <packaging>hpi</packaging>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>1.0.4</version>
   <name>Logstash</name>
   <description>A Logstash agent to send Jenkins logs to a Logstash indexer.</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Logstash+Plugin</url>
@@ -57,6 +57,12 @@
       <version>3.3.5</version>
       <type>jar</type>
       <scope>compile</scope>
+    </dependency>
+    
+    <dependency>
+	    <groupId>org.apache.activemq</groupId>
+	    <artifactId>activemq-client</artifactId>
+	    <version>5.10.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,6 @@
           </excludes>
         </configuration>
       </plugin>
-      <plugin>
-          <groupId>org.jenkins-ci.tools</groupId>
-          <artifactId>maven-hpi-plugin</artifactId>
-        </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
   <artifactId>logstash</artifactId>
   <packaging>hpi</packaging>
-  <version>1.0.4</version>
+  <version>1.0.4-SNAPSHOT</version>
   <name>Logstash</name>
   <description>A Logstash agent to send Jenkins logs to a Logstash indexer.</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Logstash+Plugin</url>
@@ -120,6 +120,10 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+        </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/ActiveMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ActiveMqDao.java
@@ -41,7 +41,6 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 /**
  * ActiveMq Data Access Object.
  *
- * @author Rusty Gerard
  * @author dbs
  * @since 1.0.4
  */

--- a/src/main/java/jenkins/plugins/logstash/persistence/ActiveMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ActiveMqDao.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Rusty Gerard
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins.logstash.persistence;
+
+import java.io.PrintStream;
+
+import javax.jms.Connection;
+import javax.jms.DeliveryMode;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+
+/**
+ * ActiveMq Data Access Object.
+ *
+ * @author Rusty Gerard
+ * @author dbs
+ * @since 1.0.4
+ */
+public class ActiveMqDao extends AbstractLogstashIndexerDao {
+  //ConnectionFactory pool;
+  ActiveMQConnectionFactory connectionFactory = null;
+
+  ActiveMqDao() { /* Required by IndexerDaoFactory */ }
+
+  // Constructor for unit testing
+  ActiveMqDao(String host, int port, String key, String username, String password) {
+    init(host, port, key, username, password);
+  }
+
+  final void init(String host, int port, String key, String username, String password) {
+    super.init(host, port, key, username, password);
+
+    if (StringUtils.isBlank(key)) {
+      throw new IllegalArgumentException("JMS queue name is required");
+    }
+
+      // The ConnectionFactory must be a singleton
+      // We assume this is used as a singleton as well
+      // Calling this method means the configuration has changed and the pool must be re-initialized
+      connectionFactory = new ActiveMQConnectionFactory(String.format("tcp://%s:%d", host, port));
+      
+      if (!StringUtils.isBlank(username) && !StringUtils.isBlank(password)) {
+        connectionFactory.setUserName(username);
+        connectionFactory.setPassword(password);
+      }
+
+  }
+
+  @Override
+  public long push(String data, PrintStream logger) {
+    try {
+      // Create a Connection
+      Connection connection = connectionFactory.createConnection();
+      connection.start();
+      // Create a Session
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      
+      // Create the destination (Topic or Queue)
+      Destination destination = session.createQueue(key);
+      
+      // Create a MessageProducer from the Session to the Topic or Queue
+      MessageProducer producer = session.createProducer(destination);
+      producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+      
+      // Create a messages
+      TextMessage message = session.createTextMessage(data);
+
+      // Tell the producer to send the message
+      producer.send(message);
+
+      // Clean up
+      session.close();
+      connection.close();
+      return 1;
+    } catch (JMSException e) {
+      logger.println(ExceptionUtils.getStackTrace(e));
+    }
+    return -1;
+  }
+
+  @Override
+  public IndexerType getIndexerType() {
+    return IndexerType.JMS;
+  }
+}

--- a/src/main/java/jenkins/plugins/logstash/persistence/ActiveMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ActiveMqDao.java
@@ -107,6 +107,6 @@ public class ActiveMqDao extends AbstractLogstashIndexerDao {
 
   @Override
   public IndexerType getIndexerType() {
-    return IndexerType.JMS;
+    return IndexerType.ACTIVE_MQ;
   }
 }

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -25,6 +25,7 @@
 package jenkins.plugins.logstash.persistence;
 
 import hudson.model.Action;
+import hudson.model.Environment;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.model.Node;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -139,6 +141,18 @@ public class BuildData {
     rootProjectDisplayName = build.getRootBuild().getDisplayName();
     rootBuildNum = build.getRootBuild().getNumber();
     buildVariables = build.getBuildVariables();
+
+    Map<String, String> env = new HashMap<String, String>();
+    List<Environment> environmentList = build.getEnvironments();
+    if (environmentList != null) {
+      for (Environment e : environmentList) {
+        if (e != null) {
+          e.buildEnvVars(env);
+          if(!env.isEmpty())
+            buildVariables.putAll(env);
+        }
+      }
+    }
   }
 
   @Override

--- a/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
@@ -50,7 +50,7 @@ public final class IndexerDaoFactory {
     indexerMap.put(IndexerType.REDIS, RedisDao.class);
     indexerMap.put(IndexerType.RABBIT_MQ, RabbitMqDao.class);
     indexerMap.put(IndexerType.ELASTICSEARCH, ElasticSearchDao.class);
-    indexerMap.put(IndexerType.JMS, ActiveMqDao.class);
+    indexerMap.put(IndexerType.ACTIVE_MQ, ActiveMqDao.class);
 
     INDEXER_MAP = Collections.unmodifiableMap(indexerMap);
   }

--- a/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
@@ -47,6 +47,7 @@ public final class IndexerDaoFactory {
 
     indexerMap.put(IndexerType.REDIS, RedisDao.class);
     indexerMap.put(IndexerType.RABBIT_MQ, RabbitMqDao.class);
+    indexerMap.put(IndexerType.JMS, ActiveMqDao.class);
 
     INDEXER_MAP = Collections.unmodifiableMap(indexerMap);
   }

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
@@ -38,7 +38,8 @@ import net.sf.json.JSONObject;
 public interface LogstashIndexerDao {
   static enum IndexerType {
     REDIS,
-    RABBIT_MQ
+    RABBIT_MQ,
+    JMS
   }
 
   int getPort();

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
@@ -40,7 +40,7 @@ public interface LogstashIndexerDao {
     REDIS,
     RABBIT_MQ,
     ELASTICSEARCH,
-    JMS
+    ACTIVE_MQ
   }
 
   int getPort();

--- a/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-key.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-key.html
@@ -1,4 +1,5 @@
 <div>
   <p>REDIS: The name of a Redis list or channel.<br/>
-  RABBIT_MQ: The name of a RabbitMq queue.</p>
+  RABBIT_MQ: The name of a RabbitMq queue.<br/>
+  JMS: The name of a JMS queue.</p>
 </div>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-key.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-key.html
@@ -2,5 +2,5 @@
   <p>REDIS: The name of a Redis list or channel.<br/>
   RABBIT_MQ: The name of a RabbitMq queue.<br/>
   ELASTICSEARCH: The name and type path. Example: "/indexName/type"<br/>
-  JMS: The name of a JMS queue.</p>
+  ACTIVE_MQ: The name of the Active MQ queue.</p>
 </div>

--- a/src/test/java/jenkins/plugins/logstash/LogstashNotifierTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashNotifierTest.java
@@ -6,11 +6,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.BuildListener;
+import hudson.model.Environment;
+import hudson.model.EnvironmentList;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.model.Project;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.tasks.test.AbstractTestResultAction;
 
 import java.io.IOException;
@@ -57,11 +61,16 @@ public class LogstashNotifierTest {
   @Mock BuildListener mockListener;
   @Mock PrintStream mockLogger;
   @Mock LogstashIndexerDao mockDao;
+  @Mock Environment mockEnvironment;
 
   LogstashNotifier notifier;
-
+  
   @Before
   public void before() throws Exception {
+    EnvVars envVars = new EnvironmentVariablesNodeProperty().getEnvVars();
+    envVars.put("sampleEnvVarKey", "sampleEnvVarValue");
+    mockEnvironment.buildEnvVars(envVars);
+    
     when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
     when(mockBuild.getDisplayName()).thenReturn("LogstashNotifierTest");
     when(mockBuild.getProject()).thenReturn(mockProject);
@@ -73,6 +82,7 @@ public class LogstashNotifierTest {
     when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
     when(mockBuild.getLog(3)).thenReturn(Arrays.asList("line 1", "line 2", "line 3"));
     when(mockBuild.getAction(AbstractTestResultAction.class)).thenReturn(mockTestResultAction);
+    when(mockBuild.getEnvironments()).thenReturn(new EnvironmentList(Collections.singletonList(mockEnvironment)));
 
     when(mockTestResultAction.getTotalCount()).thenReturn(0);
     when(mockTestResultAction.getSkipCount()).thenReturn(0);
@@ -88,7 +98,7 @@ public class LogstashNotifierTest {
     when(mockDao.getIndexerType()).thenReturn(IndexerType.REDIS);
     when(mockDao.getHost()).thenReturn("localhost");
     when(mockDao.getPort()).thenReturn(8080);
-
+    
     notifier = new MockLogstashNotifier(3, false, "http://my-jenkins-url", mockDao);
   }
 
@@ -125,6 +135,7 @@ public class LogstashNotifierTest {
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getLog(3);
+    verify(mockBuild).getEnvironments();
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();
@@ -196,6 +207,7 @@ public class LogstashNotifierTest {
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getLog(3);
+    verify(mockBuild).getEnvironments();
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();
@@ -238,6 +250,7 @@ public class LogstashNotifierTest {
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getLog(3);
+    verify(mockBuild).getEnvironments();
 
     verify(mockProject, times(2)).getName();
 
@@ -272,6 +285,7 @@ public class LogstashNotifierTest {
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getLog(3);
+    verify(mockBuild).getEnvironments();
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();
@@ -317,6 +331,7 @@ public class LogstashNotifierTest {
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getLog(3);
+    verify(mockBuild).getEnvironments();
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();

--- a/src/test/java/jenkins/plugins/logstash/persistence/ActiveMqDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/ActiveMqDaoTest.java
@@ -1,0 +1,215 @@
+package jenkins.plugins.logstash.persistence;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintStream;
+import java.net.SocketException;
+
+import javax.jms.Connection;
+import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ActiveMqDaoTest {
+  ActiveMqDao dao;
+  @Mock ActiveMQConnectionFactory mockConnectionFactory;
+  @Mock Connection mockConnection;
+  @Mock Session mockSession;
+  @Mock Queue mockDestination;
+  @Mock MessageProducer mockProducer;
+  @Mock TextMessage mockMessage;
+  @Mock PrintStream mockLogger;
+
+  @Before
+  public void before() throws Exception {
+    int port = (int) (Math.random() * 1000);
+    dao = new ActiveMqDao("localhost", port, "logstash", "username", "password");
+
+    // Note that we can't run these tests in parallel
+    dao.connectionFactory = mockConnectionFactory;
+
+    when(mockConnectionFactory.createConnection()).thenReturn(mockConnection);
+
+    when(mockConnection.createSession(false, Session.AUTO_ACKNOWLEDGE)).thenReturn(mockSession);
+    
+    when(mockSession.createQueue("logstash")).thenReturn(mockDestination);
+    
+    when(mockSession.createProducer(mockDestination)).thenReturn(mockProducer);
+    
+  }
+
+  @After
+  public void after() throws Exception {
+    verifyNoMoreInteractions(mockConnectionFactory);
+    verifyNoMoreInteractions(mockConnection);
+    verifyNoMoreInteractions(mockSession);
+    verifyNoMoreInteractions(mockDestination);
+    verifyNoMoreInteractions(mockProducer);
+    verifyNoMoreInteractions(mockLogger);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailNullHost() throws Exception {
+    try {
+      new ActiveMqDao(null, 5672, "logstash", "username", "password");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "host name is required", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailEmptyHost() throws Exception {
+    try {
+      new ActiveMqDao(" ", 5672, "logstash", "username", "password");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "host name is required", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailNullKey() throws Exception {
+    try {
+      new ActiveMqDao("localhost", 5672, null, "username", "password");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "jms queue name is required", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailEmptyKey() throws Exception {
+    try {
+      new ActiveMqDao("localhost", 5672, " ", "username", "password");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "jms queue name is required", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test
+  public void constructorSuccess() throws Exception {
+    // Unit under test
+    dao = new ActiveMqDao("localhost", 5672, "logstash", "username", "password");
+
+    // Verify results
+    assertEquals("Wrong host name", "localhost", dao.host);
+    assertEquals("Wrong port", 5672, dao.port);
+    assertEquals("Wrong key", "logstash", dao.key);
+    assertEquals("Wrong password", "password", dao.password);
+  }
+
+  //@Test
+  public void pushFailUnauthorized() throws Exception {
+    // Initialize mocks
+    when(mockConnectionFactory.createConnection()).thenThrow(new JMSException("Not authorized"));
+
+    // Unit under test
+    long result = dao.push("", mockLogger);
+
+    // Verify results
+    assertEquals("Return code should be an error", -1L, result);
+
+    verify(mockConnectionFactory).createConnection();
+    verify(mockLogger).println(Matchers.startsWith("javax.jms.JMSException: Not authorized"));
+  }
+
+  //@Test
+  public void pushFailCantConnect() throws Exception {
+    // Initialize mocks
+    when(mockConnectionFactory.createConnection()).thenThrow(new SocketException("Connection refused"));
+
+    // Unit under test
+    long result = dao.push("", mockLogger);
+
+    // Verify results
+    assertEquals("Return code should be an error", -1L, result);
+
+    verify(mockConnectionFactory).createConnection();
+    verify(mockLogger).println(Matchers.startsWith("java.net.SocketException: Connection refused"));
+  }
+
+  //@Test
+  public void pushFailCantWrite() throws Exception {
+    // Initialize mocks
+    doThrow(new SocketException("Queue length limit exceeded")).when(mockProducer).send(mockSession.createTextMessage("{}"));
+
+    // Unit under test
+    long result = dao.push("{}", mockLogger);
+
+    // Verify results
+    assertEquals("Return code should be an error", -1L, result);
+
+    verify(mockConnectionFactory).createConnection();
+    verify(mockConnection).createSession(false, Session.AUTO_ACKNOWLEDGE);
+    verify(mockSession).createQueue("logstash");
+    verify(mockSession).createProducer(mockDestination);
+    mockProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+    verify(mockSession).createTextMessage("{}");
+    verify(mockProducer).send(mockMessage);
+    verify(mockLogger).println(Matchers.startsWith("java.net.SocketException: Queue length limit exceeded"));
+  }
+
+  @Test
+  public void pushSuccess() throws Exception {
+    String json = "{ 'foo': 'bar' }";
+
+    // Unit under test
+    long result = dao.push(json, mockLogger);
+
+    // Verify results
+    assertEquals("Unexpected return code", 1L, result);
+
+    verify(mockConnectionFactory).createConnection();
+    verify(mockConnection).createSession(false, Session.AUTO_ACKNOWLEDGE);
+    verify(mockSession).createQueue("logstash");
+    verify(mockSession).createProducer(mockDestination);
+    mockProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+    verify(mockSession).createTextMessage(json);
+    verify(mockProducer).send(mockMessage);
+    verify(mockSession).close();
+    verify(mockConnection).close();
+  }
+
+  @Test
+  public void pushSuccessNoAuth() throws Exception {
+    String json = "{ 'foo': 'bar' }";
+    dao = new ActiveMqDao("localhost", 5672, "logstash", null, null);
+    dao.connectionFactory = mockConnectionFactory;
+
+    // Unit under test
+    long result = dao.push(json, mockLogger);
+
+    // Verify results
+    assertEquals("Unexpected return code", 1L, result);
+
+    verify(mockConnectionFactory).createConnection();
+    verify(mockConnection).createSession(false, Session.AUTO_ACKNOWLEDGE);
+    verify(mockSession).createQueue("logstash");
+    verify(mockSession).createProducer(mockDestination);
+    mockProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+    verify(mockSession).createTextMessage(json);
+    verify(mockProducer).send(mockMessage);
+    verify(mockSession).close();
+    verify(mockConnection).close();
+  }
+}

--- a/src/test/java/jenkins/plugins/logstash/persistence/ActiveMqDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/ActiveMqDaoTest.java
@@ -54,6 +54,8 @@ public class ActiveMqDaoTest {
     
     when(mockSession.createProducer(mockDestination)).thenReturn(mockProducer);
     
+    when(mockSession.createTextMessage("{ 'foo': 'bar' }")).thenReturn(mockMessage);
+    
   }
 
   @After
@@ -63,6 +65,7 @@ public class ActiveMqDaoTest {
     verifyNoMoreInteractions(mockSession);
     verifyNoMoreInteractions(mockDestination);
     verifyNoMoreInteractions(mockProducer);
+    verifyNoMoreInteractions(mockMessage);
     verifyNoMoreInteractions(mockLogger);
   }
 
@@ -91,7 +94,7 @@ public class ActiveMqDaoTest {
     try {
       new ActiveMqDao("localhost", 5672, null, "username", "password");
     } catch (IllegalArgumentException e) {
-      assertEquals("Wrong error message was thrown", "jms queue name is required", e.getMessage());
+      assertEquals("Wrong error message was thrown", "JMS queue name is required", e.getMessage());
       throw e;
     }
   }
@@ -101,7 +104,7 @@ public class ActiveMqDaoTest {
     try {
       new ActiveMqDao("localhost", 5672, " ", "username", "password");
     } catch (IllegalArgumentException e) {
-      assertEquals("Wrong error message was thrown", "jms queue name is required", e.getMessage());
+      assertEquals("Wrong error message was thrown", "JMS queue name is required", e.getMessage());
       throw e;
     }
   }
@@ -180,10 +183,11 @@ public class ActiveMqDaoTest {
     assertEquals("Unexpected return code", 1L, result);
 
     verify(mockConnectionFactory).createConnection();
+    verify(mockConnection).start();
     verify(mockConnection).createSession(false, Session.AUTO_ACKNOWLEDGE);
     verify(mockSession).createQueue("logstash");
     verify(mockSession).createProducer(mockDestination);
-    mockProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+    verify(mockProducer).setDeliveryMode(DeliveryMode.NON_PERSISTENT);
     verify(mockSession).createTextMessage(json);
     verify(mockProducer).send(mockMessage);
     verify(mockSession).close();
@@ -203,10 +207,11 @@ public class ActiveMqDaoTest {
     assertEquals("Unexpected return code", 1L, result);
 
     verify(mockConnectionFactory).createConnection();
+    verify(mockConnection).start();
     verify(mockConnection).createSession(false, Session.AUTO_ACKNOWLEDGE);
     verify(mockSession).createQueue("logstash");
     verify(mockSession).createProducer(mockDestination);
-    mockProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+    verify(mockProducer).setDeliveryMode(DeliveryMode.NON_PERSISTENT);
     verify(mockSession).createTextMessage(json);
     verify(mockProducer).send(mockMessage);
     verify(mockSession).close();

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -4,10 +4,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import hudson.EnvVars;
+import hudson.model.Environment;
+import hudson.model.EnvironmentList;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.model.Node;
 import hudson.model.Project;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 
@@ -42,9 +46,13 @@ public class BuildDataTest {
   @Mock Node mockNode;
   @Mock Date mockDate;
   @Mock GregorianCalendar mockCalendar;
+  @Mock Environment mockEnvironment;
 
   @Before
   public void before() throws Exception {
+    EnvVars envVars = new EnvironmentVariablesNodeProperty().getEnvVars();
+    envVars.put("sampleEnvVarKey", "sampleEnvVarValue");
+    mockEnvironment.buildEnvVars(envVars);
     when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
     when(mockBuild.getDisplayName()).thenReturn("BuildDataTest");
     when(mockBuild.getFullDisplayName()).thenReturn("BuildDataTest #123456");
@@ -57,6 +65,7 @@ public class BuildDataTest {
     when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
     when(mockBuild.getLog(3)).thenReturn(Arrays.asList("line 1", "line 2", "line 3"));
     when(mockBuild.getAction(AbstractTestResultAction.class)).thenReturn(mockTestResultAction);
+    when(mockBuild.getEnvironments()).thenReturn(new EnvironmentList(Collections.singletonList(mockEnvironment)));
 
     when(mockTestResultAction.getTotalCount()).thenReturn(0);
     when(mockTestResultAction.getSkipCount()).thenReturn(0);
@@ -102,6 +111,7 @@ public class BuildDataTest {
     verify(mockBuild).getTimestamp();
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
+    verify(mockBuild).getEnvironments();
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();
@@ -142,6 +152,7 @@ public class BuildDataTest {
     verify(mockBuild).getTimestamp();
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
+    verify(mockBuild).getEnvironments();
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();
@@ -182,6 +193,7 @@ public class BuildDataTest {
     verify(mockBuild).getTimestamp();
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
+    verify(mockBuild).getEnvironments();
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();
@@ -223,6 +235,7 @@ public class BuildDataTest {
     verify(mockBuild).getTimestamp();
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
+    verify(mockBuild).getEnvironments();
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();
@@ -256,6 +269,7 @@ public class BuildDataTest {
     verify(mockBuild).getTimestamp();
     verify(mockBuild, times(3)).getRootBuild();
     verify(mockBuild).getBuildVariables();
+    verify(mockBuild).getEnvironments();
 
     verify(mockProject, times(2)).getName();
 


### PR DESCRIPTION
Hi 
I contribute JMS (ActiveMQ implementation) to logstash plugin.
It has been working very nice for 1 month already in production, no problems.

Beside JMS, I added few line in BuildData.
I did that because one of the main use of this plugin was to feed another system which need a more extensive set of environment variables than the very limited ones provided by getBuildVariables.

Our jenkins job produce lots of dynamic EnvVars which are necessary to forward to other systems.
It maybe possible to make it optional, but I' m not familiar with Jenkins Jelly.

Unit Tests run fine.

Thanks to make available to the community this plugin.
Regards,