### PR TITLE
Create common LogstashWriter

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
@@ -33,8 +33,6 @@ import hudson.util.FormValidation;
 import java.util.List;
 
 import jenkins.model.Jenkins;
-import jenkins.plugins.logstash.persistence.IndexerDaoFactory;
-import jenkins.plugins.logstash.persistence.LogstashIndexerDao;
 import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
 import net.sf.json.JSONObject;
 
@@ -92,13 +90,6 @@ public class LogstashInstallation extends ToolInstallation {
     @Override
     public String getDisplayName() {
       return Messages.DisplayName();
-    }
-
-    /**
-     * @see IndexerDaoFactory#getInstance(IndexerType, String, Integer, String, String, String)
-     */
-    public LogstashIndexerDao getIndexerDao() throws InstantiationException {
-      return IndexerDaoFactory.getInstance(type, host, port, key, username, password);
     }
 
     /*

--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -1,0 +1,187 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Rusty Gerard and Liam Newman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins.logstash;
+
+
+import hudson.model.AbstractBuild;
+import jenkins.model.Jenkins;
+import jenkins.plugins.logstash.persistence.BuildData;
+import jenkins.plugins.logstash.persistence.IndexerDaoFactory;
+import jenkins.plugins.logstash.persistence.LogstashIndexerDao;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A writer that wraps all Logstash DAOs.  Handles error reporting and per build connection state.
+ * Each call to write (one line or multiple lines) sends a Logstash payload to the DAO.
+ * If any write fails, writer will not attempt to send any further messages to logstash during this build.
+ *
+ * @author Rusty Gerard
+ * @author Liam Newman
+ * @since 1.0.5
+ */
+public class LogstashWriter {
+
+  final OutputStream errorStream;
+  final AbstractBuild<?, ?> build;
+  final BuildData buildData;
+  final String jenkinsUrl;
+  final LogstashIndexerDao dao;
+  private boolean connectionBroken;
+
+  public LogstashWriter(AbstractBuild<?, ?> build, OutputStream error) {
+    this.errorStream = error != null ? error : System.err;
+    this.build = build;
+    this.dao = this.getDaoOrNull();
+    if (this.dao == null) {
+      this.jenkinsUrl = "";
+      this.buildData = null;
+    } else {
+      this.jenkinsUrl = getJenkinsUrl();
+      this.buildData = getBuildData();
+    }
+
+  }
+
+  /**
+   * Sends a logstash payload for a single line to the indexer.
+   * Call will be ignored if the line is empty or if the connection to the indexer is broken.
+   * If write fails, errors will logged to errorStream and connectionBroken will be set to true.
+   *
+   * @param line
+   *          Message, not null
+   */
+  public void write(String line) {
+    if (!isConnectionBroken() && StringUtils.isNotEmpty(line)) {
+      this.write(Arrays.asList(line));
+    }
+  }
+
+  /**
+   * Sends a logstash payload containing log lines from the current build.
+   * Call will be ignored if the connection to the indexer is broken.
+   * If write fails, errors will logged to errorStream and connectionBroken will be set to true.
+   *
+   * @param maxLines
+   *          Maximum number of lines to be written.  Negative numbers mean "all lines".
+   */
+  public void writeBuildLog(int maxLines) {
+    if (!isConnectionBroken()) {
+      // FIXME: build.getLog() won't have the last few lines like "Finished: SUCCESS" because this hasn't returned yet...
+      List<String> logLines;
+      try {
+        if (maxLines < 0) {
+          logLines = build.getLog(Integer.MAX_VALUE);
+        } else {
+          logLines = build.getLog(maxLines);
+        }
+      } catch (IOException e) {
+        String msg = "[logstash-plugin]: Unable to serialize log data.\n" +
+          ExceptionUtils.getStackTrace(e);
+        logErrorMessage(msg);
+
+        // Continue with error info as logstash payload
+        logLines = Arrays.asList(msg.split("\n"));
+      }
+
+      write(logLines);
+    }
+  }
+
+  /**
+   * @return True if errors have occurred during initialization or write.
+   */
+  public boolean isConnectionBroken() {
+    return connectionBroken || build == null || dao == null || buildData == null;
+  }
+
+  // Method to encapsulate calls for unit-testing
+  LogstashIndexerDao getDao() throws InstantiationException {
+    LogstashInstallation.Descriptor descriptor = LogstashInstallation.getLogstashDescriptor();
+    return IndexerDaoFactory.getInstance(descriptor.type, descriptor.host, descriptor.port, descriptor.key, descriptor.username, descriptor.password);
+  }
+
+  BuildData getBuildData() {
+    return new BuildData(build, new Date());
+  }
+
+  String getJenkinsUrl() {
+    return Jenkins.getInstance().getRootUrl();
+  }
+
+  /**
+   * Write a list of lines to the indexer as one Logstash payload.
+   */
+  private void write(List<String> lines) {
+    JSONObject payload = dao.buildPayload(buildData, jenkinsUrl, lines);
+    try {
+      dao.push(payload.toString());
+    } catch (IOException e) {
+      String msg = "[logstash-plugin]: Failed to send log data to " + dao.getIndexerType() + ":" + dao.getDescription() + ".\n" +
+        "[logstash-plugin]: No Further logs will be sent to " + dao.getDescription() + ".\n" +
+        ExceptionUtils.getStackTrace(e);
+      logErrorMessage(msg);
+    }
+  }
+
+  /**
+   * Construct a valid indexerDao or return null.
+   * Writes errors to errorStream if dao constructor fails.
+   *
+   * @return valid {@link LogstashIndexerDao} or return null.
+   */
+  private LogstashIndexerDao getDaoOrNull() {
+    try {
+      return getDao();
+    } catch (InstantiationException e) {
+      String msg =  ExceptionUtils.getMessage(e) + "\n" +
+        "[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n";
+
+      logErrorMessage(msg);
+    }
+    return null;
+  }
+
+  /**
+   * Write error message to errorStream and set connectionBroken to true.
+   */
+  private void logErrorMessage(String msg) {
+    try {
+      connectionBroken = true;
+      errorStream.write(msg.getBytes());
+      errorStream.flush();
+    } catch (IOException ex) {
+      // This should never happen, but if it does we just have to let it go.
+      ex.printStackTrace();
+    }
+  }
+}

--- a/src/test/java/jenkins/plugins/logstash/LogstashBuildWrapperTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashBuildWrapperTest.java
@@ -3,20 +3,15 @@ package jenkins.plugins.logstash;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.verify;
 
-import hudson.model.Result;
 import hudson.model.AbstractBuild;
-import hudson.model.Project;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.GregorianCalendar;
 
-import jenkins.plugins.logstash.persistence.LogstashIndexerDao;
-import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
+import jenkins.plugins.logstash.persistence.BuildData;
 
 import org.junit.After;
 import org.junit.Before;
@@ -28,65 +23,52 @@ import org.mockito.runners.MockitoJUnitRunner;
 @SuppressWarnings("rawtypes")
 @RunWith(MockitoJUnitRunner.class)
 public class LogstashBuildWrapperTest {
-  // Extension of the unit under test that avoids making calls to Jenkins.getInstance() to get the DAO singleton
+  // Extension of the unit under test that avoids making calls to statics or constructors
   static class MockLogstashBuildWrapper extends LogstashBuildWrapper {
-    LogstashIndexerDao dao;
+    LogstashWriter writer;
 
-    MockLogstashBuildWrapper(LogstashIndexerDao dao) {
+    MockLogstashBuildWrapper(LogstashWriter writer) {
       super();
-      this.dao = dao;
+      this.writer = writer;
     }
 
     @Override
-    LogstashIndexerDao getDao() throws InstantiationException {
-      if (dao == null) {
-        throw new InstantiationException("DoaTestInstantiationException");
+    LogstashWriter getLogStashWriter(AbstractBuild<?, ?> build, OutputStream errorStream) {
+      // Simulate bad Writer
+      if(writer.isConnectionBroken()) {
+        try {
+          errorStream.write("Mocked Constructor failure".getBytes());
+        } catch (IOException e) {
+        }
       }
-
-      return dao;
-    }
-
-    @Override
-    String getJenkinsUrl() {
-      return "http://my-jenkins-url";
+      return writer;
     }
   }
 
   ByteArrayOutputStream buffer;
 
-  @Mock AbstractBuild mockBuild;
-  @Mock Project mockProject;
-  @Mock LogstashIndexerDao mockDao;
+  @Mock AbstractBuild<?, ?> mockBuild;
+  @Mock BuildData mockBuildData;
+  @Mock LogstashWriter mockWriter;
 
   @Before
   public void before() throws Exception {
-    when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
-    when(mockBuild.getDisplayName()).thenReturn("LogstashNotifierTest");
-    when(mockBuild.getProject()).thenReturn(mockProject);
-    when(mockBuild.getBuiltOn()).thenReturn(null);
-    when(mockBuild.getNumber()).thenReturn(123456);
-    when(mockBuild.getDuration()).thenReturn(60L);
-    when(mockBuild.getTimestamp()).thenReturn(new GregorianCalendar());
-    when(mockBuild.getRootBuild()).thenReturn(mockBuild);
-    when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
-    when(mockBuild.getLog(3)).thenReturn(Arrays.asList("line 1", "line 2", "line 3"));
-
-    when(mockProject.getName()).thenReturn("LogstashNotifierTest");
-
-    when(mockDao.getIndexerType()).thenReturn(IndexerType.REDIS);
-    when(mockDao.getDescription()).thenReturn("localhost:8080");
+    when(mockWriter.isConnectionBroken()).thenReturn(false);
 
     buffer = new ByteArrayOutputStream();
   }
 
   @After
   public void after() throws Exception {
-    verifyNoMoreInteractions(mockDao);
+    verifyNoMoreInteractions(mockWriter);
+    verifyNoMoreInteractions(mockBuild);
+    verifyNoMoreInteractions(mockBuildData);
+    buffer.close();
   }
 
   @Test
   public void decorateLoggerSuccess() throws Exception {
-    MockLogstashBuildWrapper buildWrapper = new MockLogstashBuildWrapper(mockDao);
+    MockLogstashBuildWrapper buildWrapper = new MockLogstashBuildWrapper(mockWriter);
 
     // Unit under test
     OutputStream result = buildWrapper.decorateLogger(mockBuild, buffer);
@@ -94,12 +76,16 @@ public class LogstashBuildWrapperTest {
     // Verify results
     assertNotNull("Result was null", result);
     assertTrue("Result is not the right type", result instanceof LogstashOutputStream);
+    assertSame("Result has wrong writer", mockWriter, ((LogstashOutputStream) result).logstash);
     assertEquals("Results don't match", "", buffer.toString());
+    verify(mockWriter).isConnectionBroken();
   }
 
   @Test
-  public void decorateLoggerSuccessNoDao() throws Exception {
-    MockLogstashBuildWrapper buildWrapper = new MockLogstashBuildWrapper(null);
+  public void decorateLoggerSuccessBadWriter() throws Exception {
+    when(mockWriter.isConnectionBroken()).thenReturn(true);
+
+    MockLogstashBuildWrapper buildWrapper = new MockLogstashBuildWrapper(mockWriter);
 
     // Unit under test
     OutputStream result = buildWrapper.decorateLogger(mockBuild, buffer);
@@ -107,6 +93,8 @@ public class LogstashBuildWrapperTest {
     // Verify results
     assertNotNull("Result was null", result);
     assertTrue("Result is not the right type", result instanceof LogstashOutputStream);
-    assertThat("Results don't match", buffer.toString(), containsString("[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n[logstash-plugin]: No Further logs will be sent.\n"));
+    assertSame("Result has wrong writer", mockWriter, ((LogstashOutputStream) result).logstash);
+    assertEquals("Error was not written", "Mocked Constructor failure", buffer.toString());
+    verify(mockWriter).isConnectionBroken();
   }
 }

--- a/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
@@ -1,22 +1,15 @@
 package jenkins.plugins.logstash;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;
-
-import jenkins.plugins.logstash.persistence.BuildData;
-import jenkins.plugins.logstash.persistence.LogstashIndexerDao;
-import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
-import net.sf.json.JSONObject;
+import java.io.OutputStream;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -24,49 +17,38 @@ import org.mockito.runners.MockitoJUnitRunner;
 @SuppressWarnings("resource")
 @RunWith(MockitoJUnitRunner.class)
 public class LogstashOutputStreamTest {
+  // Extension of the unit under test that avoids making calls to getInstance() to get the DAO singleton
+  static LogstashOutputStream createLogstashOutputStream(OutputStream delegate, LogstashWriter logstash) {
+    return new LogstashOutputStream(delegate, logstash);
+  }
 
   ByteArrayOutputStream buffer;
-
-  @Mock LogstashIndexerDao mockDao;
-  @Mock BuildData mockBuildData;
+  @Mock LogstashWriter mockWriter;
 
   @Before
   public void before() throws Exception {
-    when(mockDao.buildPayload(Matchers.any(BuildData.class), Matchers.anyString(), Matchers.anyListOf(String.class))).thenReturn(new JSONObject());
-    Mockito.doNothing().when(mockDao).push(Matchers.startsWith("{}"));
-    when(mockDao.getIndexerType()).thenReturn(IndexerType.REDIS);
-    when(mockDao.getDescription()).thenReturn("localhost:8080");
-
     buffer = new ByteArrayOutputStream();
+    Mockito.doNothing().when(mockWriter).write(anyString());
+    when(mockWriter.isConnectionBroken()).thenReturn(false);
   }
 
   @After
   public void after() throws Exception {
-    verifyNoMoreInteractions(mockDao);
-    verifyNoMoreInteractions(mockBuildData);
+    verifyNoMoreInteractions(mockWriter);
     buffer.close();
   }
 
   @Test
   public void constructorSuccess() throws Exception {
-    new LogstashOutputStream(buffer, mockDao, mockBuildData, "http://my-jenkins-url");
+    new LogstashOutputStream(buffer, mockWriter);
 
     // Verify results
     assertEquals("Results don't match", "", buffer.toString());
   }
 
   @Test
-  public void constructorSuccessNoDao() throws Exception {
-    // Unit under test
-    new LogstashOutputStream(buffer, null, mockBuildData, "http://my-jenkins-url");
-
-    // Verify results
-    assertEquals("Results don't match", "[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n[logstash-plugin]: No Further logs will be sent.\n", buffer.toString());
-  }
-
-  @Test
   public void eolSuccess() throws Exception {
-    LogstashOutputStream los = new LogstashOutputStream(buffer, mockDao, mockBuildData, "http://my-jenkins-url");
+    LogstashOutputStream los = new LogstashOutputStream(buffer, mockWriter);
     String msg = "test";
     buffer.reset();
 
@@ -75,14 +57,54 @@ public class LogstashOutputStreamTest {
 
     // Verify results
     assertEquals("Results don't match", msg, buffer.toString());
+    verify(mockWriter).isConnectionBroken();
+    verify(mockWriter).write(msg);
+  }
 
-    verify(mockDao).buildPayload(Matchers.eq(mockBuildData), Matchers.eq("http://my-jenkins-url"), Matchers.anyListOf(String.class));
-    verify(mockDao).push("{}");
+  @Test
+  public void eolSuccessConnectionBroken() throws Exception {
+    String msg = "test";
+    LogstashOutputStream los = new LogstashOutputStream(buffer, mockWriter);
+
+    String exMessage = "[logstash-plugin]: Failed to send log data to REDIS:localhost:8080.\n" +
+      "[logstash-plugin]: No Further logs will be sent.\n" +
+      "java.io.IOException: BOOM!\n";
+
+    buffer.reset();
+
+    // Unit under test
+    los.eol(msg.getBytes(), msg.length());
+
+    // Verify results
+    assertEquals("Results don't match", msg, buffer.toString());
+
+    // Break the dao connnection after this write
+    buffer.reset();
+
+    // Unit under test
+    los.eol(msg.getBytes(), msg.length());
+
+    // Verify results
+    assertEquals("Results don't match", msg, buffer.toString());
+    when(mockWriter.isConnectionBroken()).thenReturn(true);
+
+    // Verify logs still write but on further calls are made to dao
+    buffer.reset();
+    // Unit under test
+    los.eol(msg.getBytes(), msg.length());
+
+    // Verify results
+    assertEquals("Results don't match", msg, buffer.toString());
+
+    //Verify calls were made to the dao logging twice, not three times.
+    verify(mockWriter, times(2)).write(msg);
+    verify(mockWriter, times(3)).isConnectionBroken();
   }
 
   @Test
   public void eolSuccessNoDao() throws Exception {
-    LogstashOutputStream los = new LogstashOutputStream(buffer, null, mockBuildData, "http://my-jenkins-url");
+    when(mockWriter.isConnectionBroken()).thenReturn(true);
+    LogstashOutputStream los = new LogstashOutputStream(buffer, mockWriter);
     String msg = "test";
     buffer.reset();
 
@@ -91,5 +113,6 @@ public class LogstashOutputStreamTest {
 
     // Verify results
     assertEquals("Results don't match", msg, buffer.toString());
+    verify(mockWriter).isConnectionBroken();
   }
 }

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -1,0 +1,304 @@
+package jenkins.plugins.logstash;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Project;
+import hudson.model.Result;
+import hudson.tasks.test.AbstractTestResultAction;
+import jenkins.plugins.logstash.persistence.BuildData;
+import jenkins.plugins.logstash.persistence.LogstashIndexerDao;
+import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LogstashWriterTest {
+  // Extension of the unit under test that avoids making calls to getInstance() to get the DAO singleton
+  static LogstashWriter createLogstashWriter(final AbstractBuild<?, ?> testBuild,
+                                             OutputStream error,
+                                             final String url,
+                                             final LogstashIndexerDao indexer,
+                                             final BuildData data) {
+    return new LogstashWriter(testBuild, error) {
+      @Override
+      LogstashIndexerDao getDao() throws InstantiationException {
+        if (indexer == null) {
+          throw new InstantiationException("DoaTestInstantiationException");
+        }
+
+        return indexer;
+      }
+
+      @Override
+      BuildData getBuildData() {
+        assertNotNull("BuildData should never be requested for missing dao.", this.dao);
+
+        // For testing, providing null data means use the actual method
+        if (data == null) {
+          return super.getBuildData();
+        } else {
+          return data;
+        }
+      }
+
+      @Override
+      String getJenkinsUrl() {
+        return url;
+      }
+    };
+  }
+
+  ByteArrayOutputStream errorBuffer;
+
+  @Mock LogstashIndexerDao mockDao;
+  @Mock AbstractBuild mockBuild;
+  @Mock AbstractTestResultAction mockTestResultAction;
+  @Mock Project mockProject;
+
+  @Mock BuildData mockBuildData;
+
+  @Captor ArgumentCaptor<List<String>> logLinesCaptor;
+
+  @Before
+  public void before() throws Exception {
+
+    when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
+    when(mockBuild.getDisplayName()).thenReturn("LogstashNotifierTest");
+    when(mockBuild.getProject()).thenReturn(mockProject);
+    when(mockBuild.getBuiltOn()).thenReturn(null);
+    when(mockBuild.getNumber()).thenReturn(123456);
+    when(mockBuild.getDuration()).thenReturn(0L);
+    when(mockBuild.getTimestamp()).thenReturn(new GregorianCalendar());
+    when(mockBuild.getRootBuild()).thenReturn(mockBuild);
+    when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
+    when(mockBuild.getEnvironments()).thenReturn(null);
+    when(mockBuild.getAction(AbstractTestResultAction.class)).thenReturn(mockTestResultAction);
+    when(mockBuild.getLog(0)).thenReturn(Arrays.asList());
+    when(mockBuild.getLog(3)).thenReturn(Arrays.asList("line 1", "line 2", "line 3", "Log truncated..."));
+    when(mockBuild.getLog(Integer.MAX_VALUE)).thenReturn(Arrays.asList("line 1", "line 2", "line 3", "line 4"));
+
+    when(mockTestResultAction.getTotalCount()).thenReturn(0);
+    when(mockTestResultAction.getSkipCount()).thenReturn(0);
+    when(mockTestResultAction.getFailCount()).thenReturn(0);
+    when(mockTestResultAction.getFailedTests()).thenReturn(Collections.emptyList());
+
+    when(mockProject.getName()).thenReturn("LogstashWriterTest");
+
+    when(mockDao.buildPayload(Matchers.any(BuildData.class), Matchers.anyString(), Matchers.anyListOf(String.class)))
+      .thenReturn(JSONObject.fromObject("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}"));
+
+    Mockito.doNothing().when(mockDao).push(Matchers.anyString());
+    when(mockDao.getIndexerType()).thenReturn(IndexerType.REDIS);
+    when(mockDao.getDescription()).thenReturn("localhost:8080");
+
+    errorBuffer = new ByteArrayOutputStream();
+  }
+
+  @After
+  public void after() throws Exception {
+    verifyNoMoreInteractions(mockDao);
+    verifyNoMoreInteractions(mockBuild);
+    verifyNoMoreInteractions(mockBuildData);
+    verifyNoMoreInteractions(mockTestResultAction);
+    verifyNoMoreInteractions(mockProject);
+    errorBuffer.close();
+  }
+
+  @Test
+  public void constructorSuccess() throws Exception {
+    createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", mockDao, null);
+
+    // Verify that the BuildData constructor is what is being called here.
+    // This also lets us verify that in the instantiation failure cases we do not construct BuildData.
+    verify(mockBuild).getId();
+    verify(mockBuild, times(2)).getResult();
+    verify(mockBuild, times(2)).getParent();
+    verify(mockBuild, times(2)).getDisplayName();
+    verify(mockBuild).getFullDisplayName();
+    verify(mockBuild).getDescription();
+    verify(mockBuild).getUrl();
+    verify(mockBuild).getAction(AbstractTestResultAction.class);
+    verify(mockBuild).getBuiltOn();
+    verify(mockBuild, times(2)).getNumber();
+    verify(mockBuild).getTimestamp();
+    verify(mockBuild, times(3)).getRootBuild();
+    verify(mockBuild).getBuildVariables();
+    verify(mockBuild).getEnvironments();
+
+    verify(mockTestResultAction).getTotalCount();
+    verify(mockTestResultAction).getSkipCount();
+    verify(mockTestResultAction).getFailCount();
+    verify(mockTestResultAction, times(2)).getFailedTests();
+
+    verify(mockProject, times(2)).getName();
+
+    // Verify results
+    assertEquals("Results don't match", "", errorBuffer.toString());
+  }
+
+  @Test
+  public void constructorSuccessNoDao() throws Exception {
+    String exMessage = "InstantiationException: DoaTestInstantiationException\n" +
+      "[logstash-plugin]: Unable to instantiate LogstashIndexerDao with current configuration.\n";
+
+    // Unit under test
+    LogstashWriter writer = createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", null, null);
+
+    // Verify results
+    assertEquals("Results don't match", exMessage, errorBuffer.toString());
+    assertTrue("Connection not broken", writer.isConnectionBroken());
+  }
+
+  @Test
+  public void writeSuccessNoDao() throws Exception {
+    LogstashWriter writer = createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", null, null);
+    assertTrue("Connection not broken", writer.isConnectionBroken());
+
+    String msg = "test";
+    errorBuffer.reset();
+
+    // Unit under test
+    writer.write(msg);
+
+    // Verify results
+    assertEquals("Results don't match", "", errorBuffer.toString());
+    assertTrue("Connection not broken", writer.isConnectionBroken());
+  }
+
+  @Test
+  public void writeBuildLogSuccessNoDao() throws Exception {
+    LogstashWriter writer = createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", null, null);
+    assertTrue("Connection not broken", writer.isConnectionBroken());
+
+    String msg = "test";
+    errorBuffer.reset();
+
+    // Unit under test
+    writer.writeBuildLog(3);
+
+    // Verify results
+    assertEquals("Results don't match", "", errorBuffer.toString());
+    assertTrue("Connection not broken", writer.isConnectionBroken());
+  }
+
+  @Test
+  public void writeSuccess() throws Exception {
+    LogstashWriter writer = createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", mockDao, mockBuildData);
+    String msg = "test";
+    errorBuffer.reset();
+
+    // Unit under test
+    writer.write(msg);
+
+    // Verify results
+    // No error output
+    assertEquals("Results don't match", "", errorBuffer.toString());
+
+    verify(mockDao).buildPayload(Matchers.eq(mockBuildData), Matchers.eq("http://my-jenkins-url"), Matchers.anyListOf(String.class));
+    verify(mockDao).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
+  }
+
+  @Test
+  public void writeBuildLogSuccess() throws Exception {
+    LogstashWriter writer = createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", mockDao, mockBuildData);
+    errorBuffer.reset();
+
+    // Unit under test
+    writer.writeBuildLog(3);
+
+    // Verify results
+    // No error output
+    assertEquals("Results don't match", "", errorBuffer.toString());
+    verify(mockBuild).getLog(3);
+
+    verify(mockDao).buildPayload(Matchers.eq(mockBuildData), Matchers.eq("http://my-jenkins-url"), Matchers.anyListOf(String.class));
+    verify(mockDao).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
+  }
+
+  @Test
+  public void writeSuccessConnectionBroken() throws Exception {
+    Mockito.doNothing().doThrow(new IOException("BOOM!")).doNothing().when(mockDao).push(anyString());
+    LogstashWriter los = createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", mockDao, mockBuildData);
+
+
+    String msg = "test";
+    String exMessage = "[logstash-plugin]: Failed to send log data to REDIS:localhost:8080.\n" +
+      "[logstash-plugin]: No Further logs will be sent to localhost:8080.\n" +
+      "java.io.IOException: BOOM!";
+
+    errorBuffer.reset();
+
+    // Unit under test
+    los.write(msg);
+
+    // Verify results
+    assertEquals("Results don't match", "", errorBuffer.toString());
+
+    // Break the dao connnection
+    errorBuffer.reset();
+
+    // Unit under test
+    los.write(msg);
+
+    // Verify results
+    assertTrue("Results don't match", errorBuffer.toString().startsWith(exMessage));
+    assertTrue("Connection not broken", los.isConnectionBroken());
+
+    // Verify logs still write but on further calls are made to dao
+    errorBuffer.reset();
+    // Unit under test
+    los.write(msg);
+
+    // Verify results
+    assertEquals("Results don't match", "", errorBuffer.toString());
+
+    //Verify calls were made to the dao logging twice, not three times.
+    verify(mockDao, times(2)).buildPayload(Matchers.eq(mockBuildData), Matchers.eq("http://my-jenkins-url"), Matchers.anyListOf(String.class));
+    verify(mockDao, times(2)).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
+    verify(mockDao).getIndexerType();
+    verify(mockDao, times(2)).getDescription();
+  }
+
+  @Test
+  public void writeBuildLogGetLogError() throws Exception {
+    // Initialize mocks
+    when(mockBuild.getLog(3)).thenThrow(new IOException("Unable to read log file"));
+
+    LogstashWriter writer = createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", mockDao, mockBuildData);
+    assertEquals("Errors were written", "", errorBuffer.toString());
+
+    // Unit under test
+    writer.writeBuildLog(3);
+
+    // Verify results
+    verify(mockBuild).getLog(3);
+
+    List<String> expectedErrorLines =  Arrays.asList(
+      "[logstash-plugin]: Unable to serialize log data.",
+      "java.io.IOException: Unable to read log file");
+    verify(mockDao).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
+    verify(mockDao).buildPayload(eq(mockBuildData), eq("http://my-jenkins-url"), logLinesCaptor.capture());
+    List<String> actualLogLines = logLinesCaptor.getValue();
+
+    assertEquals("The exception was not sent to Logstash", actualLogLines.get(0), expectedErrorLines.get(0));
+    assertEquals("The exception was not sent to Logstash", actualLogLines.get(1), expectedErrorLines.get(1));
+  }
+}

--- a/src/test/java/jenkins/plugins/logstash/persistence/RabbitMqDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/RabbitMqDaoTest.java
@@ -1,7 +1,6 @@
 package jenkins.plugins.logstash.persistence;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -13,7 +12,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 

--- a/src/test/java/jenkins/plugins/logstash/persistence/RedisDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/RedisDaoTest.java
@@ -1,7 +1,6 @@
 package jenkins.plugins.logstash.persistence;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -12,9 +11,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import redis.clients.jedis.Jedis;


### PR DESCRIPTION
Sorry for the large commit, but things get much simpler this way.

LogstashNotifier, LogstashBuildWrapper, and LogstashOutputStream become relatively thin adapters the feed into a common LogstashWriter.  The LogstashWriter handles error reporting and per build connection state. 
