### PR TITLE
Allow to configure a reverse-proxy without any port specified

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
@@ -26,20 +26,18 @@ package jenkins.plugins.logstash;
 
 import hudson.Extension;
 import hudson.tools.ToolDescriptor;
-import hudson.tools.ToolProperty;
 import hudson.tools.ToolInstallation;
+import hudson.tools.ToolProperty;
 import hudson.util.FormValidation;
-
-import java.util.List;
-
 import jenkins.model.Jenkins;
 import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
 import net.sf.json.JSONObject;
-
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.List;
 
 /**
  * POJO for storing global configurations shared between components.
@@ -63,7 +61,7 @@ public class LogstashInstallation extends ToolInstallation {
   public static final class Descriptor extends ToolDescriptor<LogstashInstallation> {
     public IndexerType type;
     public String host;
-    public Integer port = -1;
+    public String port;
     public String username;
     public String password;
     public String key;

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -24,11 +24,10 @@
 
 package jenkins.plugins.logstash.persistence;
 
-import java.util.List;
-
+import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 
-import net.sf.json.JSONObject;
+import java.util.List;
 
 /**
  * Abstract data access object for Logstash indexers.
@@ -38,12 +37,12 @@ import net.sf.json.JSONObject;
  */
 abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
   protected final String host;
-  protected final int port;
+  protected final String port;
   protected final String key;
   protected final String username;
   protected final String password;
 
-  AbstractLogstashIndexerDao(String host, int port, String key, String username, String password) {
+  AbstractLogstashIndexerDao(String host, String port, String key, String username, String password) {
     this.host = host;
     this.port = port;
     this.key = key;

--- a/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
@@ -53,12 +53,12 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
   final String auth;
 
   //primary constructor used by indexer factory
-  public ElasticSearchDao(String host, int port, String key, String username, String password) {
+  public ElasticSearchDao(String host, String port, String key, String username, String password) {
     this(null, host, port, key, username, password);
   }
 
   // Factored for unit testing
-  ElasticSearchDao(HttpClientBuilder factory, String host, int port, String key, String username, String password) {
+  ElasticSearchDao(HttpClientBuilder factory, String host, String port, String key, String username, String password) {
     super(host, port, key, username, password);
 
     if (StringUtils.isBlank(key)) {
@@ -66,11 +66,14 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
     }
 
     try {
-      uri = new URIBuilder(host)
-        .setPort(port)
-        // Normalizer will remove extra starting slashes, but missing slash will cause annoying failures
-        .setPath("/" + key)
-        .build();
+      URIBuilder uriBuilder = new URIBuilder(host);
+      if (StringUtils.isNotBlank(port)) {
+        uriBuilder.setPort(Integer.parseInt(port));
+      }
+      // Normalizer will remove extra starting slashes, but missing slash will cause annoying failures
+      String path = uriBuilder.getPath() + "/" + key;
+      uriBuilder.setPath(path.replaceAll("//", "/"));
+      uri = uriBuilder.build();
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Could not create uri", e);
     }

--- a/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
@@ -24,16 +24,15 @@
 
 package jenkins.plugins.logstash.persistence;
 
+import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
 
 /**
  * Factory for AbstractLogstashIndexerDao objects.
@@ -73,18 +72,15 @@ public final class IndexerDaoFactory {
    * @return The instance of the appropriate indexer DAO, never null
    * @throws InstantiationException
    */
-  public static synchronized LogstashIndexerDao getInstance(IndexerType type, String host, Integer port, String key, String username, String password) throws InstantiationException {
+  public static synchronized LogstashIndexerDao getInstance(IndexerType type, String host, String port, String key, String username, String password) throws InstantiationException {
     if (!INDEXER_MAP.containsKey(type)) {
       throw new InstantiationException("[logstash-plugin]: Unknown IndexerType '" + type + "'. Did you forget to configure the plugin?");
     }
 
-    // Prevent NPE
-    port = (port == null ? -1 : port.intValue());
-
     if (shouldRefreshInstance(type, host, port, key, username, password)) {
       try {
         Class<?> indexerClass = INDEXER_MAP.get(type);
-        Constructor<?> constructor = indexerClass.getConstructor(String.class, int.class, String.class, String.class, String.class);
+        Constructor<?> constructor = indexerClass.getConstructor(String.class, String.class, String.class, String.class, String.class);
         instance = (AbstractLogstashIndexerDao) constructor.newInstance(host, port, key, username, password);
       } catch (NoSuchMethodException e) {
         throw new InstantiationException(ExceptionUtils.getRootCauseMessage(e));
@@ -98,14 +94,14 @@ public final class IndexerDaoFactory {
     return instance;
   }
 
-  private static boolean shouldRefreshInstance(IndexerType type, String host, int port, String key, String username, String password) {
+  private static boolean shouldRefreshInstance(IndexerType type, String host, String port, String key, String username, String password) {
     if (instance == null) {
       return true;
     }
 
     boolean matches = (instance.getIndexerType() == type) &&
       StringUtils.equals(instance.host, host) &&
-      (instance.port == port) &&
+      StringUtils.equals(instance.port, port) &&
       StringUtils.equals(instance.key, key) &&
       StringUtils.equals(instance.username, username) &&
       StringUtils.equals(instance.password, password);

--- a/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
@@ -24,13 +24,12 @@
 
 package jenkins.plugins.logstash.persistence;
 
-import java.io.IOException;
-
-import org.apache.commons.lang.StringUtils;
-
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
 
 /**
  * RabbitMQ Data Access Object.
@@ -42,12 +41,12 @@ public class RabbitMqDao extends AbstractLogstashIndexerDao {
   final ConnectionFactory pool;
 
   //primary constructor used by indexer factory
-  public RabbitMqDao(String host, int port, String key, String username, String password) {
+  public RabbitMqDao(String host, String port, String key, String username, String password) {
     this(null, host, port, key, username, password);
   }
 
   // Factored for unit testing
-  RabbitMqDao(ConnectionFactory factory, String host, int port, String key, String username, String password) {
+  RabbitMqDao(ConnectionFactory factory, String host, String port, String key, String username, String password) {
     super(host, port, key, username, password);
 
     if (StringUtils.isBlank(key)) {
@@ -59,7 +58,10 @@ public class RabbitMqDao extends AbstractLogstashIndexerDao {
     // Calling this method means the configuration has changed and the pool must be re-initialized
     pool = factory == null ? new ConnectionFactory() : factory;
     pool.setHost(host);
-    pool.setPort(port);
+
+    if (StringUtils.isNotBlank(port)) {
+      pool.setPort(Integer.parseInt(port));
+    }
 
     if (!StringUtils.isBlank(username) && !StringUtils.isBlank(password)) {
       pool.setPassword(password);

--- a/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
@@ -24,15 +24,15 @@
 
 package jenkins.plugins.logstash.persistence;
 
-import java.io.IOException;
-
 import org.apache.commons.lang.StringUtils;
-
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
+
+import java.io.IOException;
 
 /**
  * Redis Data Access Object.
@@ -44,12 +44,12 @@ public class RedisDao extends AbstractLogstashIndexerDao {
   final JedisPool pool;
 
   //primary constructor used by indexer factory
-  public RedisDao(String host, int port, String key, String username, String password) {
+  public RedisDao(String host, String port, String key, String username, String password) {
     this(null, host, port, key, username, password);
   }
 
   // Factored for unit testing
-  RedisDao(JedisPool factory, String host, int port, String key, String username, String password) {
+  RedisDao(JedisPool factory, String host, String port, String key, String username, String password) {
     super(host, port, key, username, password);
 
     if (StringUtils.isBlank(key)) {
@@ -58,7 +58,11 @@ public class RedisDao extends AbstractLogstashIndexerDao {
 
     // The JedisPool must be a singleton
     // We assume this is used as a singleton as well
-    pool = factory == null ? new JedisPool(new JedisPoolConfig(), host, port) : factory;
+    pool = factory == null ? new JedisPool(
+        new JedisPoolConfig(),
+        host,
+        StringUtils.isNotBlank(port) ? Integer.parseInt(port) : Protocol.DEFAULT_PORT
+    ) : factory;
   }
 
   @Override

--- a/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/global.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/global.jelly
@@ -8,8 +8,7 @@
         checkUrl="'descriptorByName/LogstashInstallation/checkHost?value='+escape(this.value)" />
     </f:entry>
     <f:entry title="${%Port}" field="port">
-      <f:textbox value="${descriptor.port}" default="6379"
-        checkUrl="'descriptorByName/LogstashInstallation/checkInteger?value='+escape(this.value)" />
+      <f:textbox value="${descriptor.port}" />
     </f:entry>
     <f:entry title="${%Username}" field="username">
       <f:textbox value="${descriptor.username}" />

--- a/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-port.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-port.html
@@ -1,3 +1,3 @@
 <div>
-  <p>The port number the indexer listens on.</p>
+  <p>The port number the indexer listens on. Can be left empty if you are using a reverse-proxy for example.</p>
 </div>

--- a/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
@@ -1,19 +1,18 @@
 package jenkins.plugins.logstash.persistence;
 
-import static net.sf.json.test.JSONAssert.assertEquals;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import net.sf.json.JSONObject;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static net.sf.json.test.JSONAssert.assertEquals;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractLogstashIndexerDaoTest {
@@ -63,7 +62,7 @@ public class AbstractLogstashIndexerDaoTest {
   }
 
   private AbstractLogstashIndexerDao getInstance() {
-    return new AbstractLogstashIndexerDao("localhost", -1, "", "", "") {
+    return new AbstractLogstashIndexerDao("localhost", null, "", "", "") {
 
       public IndexerType getIndexerType() {
         return IndexerType.REDIS;

--- a/src/test/java/jenkins/plugins/logstash/persistence/IndexerDaoFactoryTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/IndexerDaoFactoryTest.java
@@ -1,10 +1,10 @@
 package jenkins.plugins.logstash.persistence;
 
+import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
-
-import org.junit.Test;
 
 public class IndexerDaoFactoryTest {
 
@@ -12,7 +12,7 @@ public class IndexerDaoFactoryTest {
   public void getAllInstances() throws Exception {
     for (IndexerType type : IndexerType.values()) {
       String host = type == IndexerType.ELASTICSEARCH ? "http://localhost" : "localhost";
-      LogstashIndexerDao dao = IndexerDaoFactory.getInstance(type, host, 1234, "key", "username", "password");
+      LogstashIndexerDao dao = IndexerDaoFactory.getInstance(type, host, "1234", "key", "username", "password");
 
       assertNotNull("Result was null", dao);
       assertEquals("Result implements wrong IndexerType", type, dao.getIndexerType());
@@ -33,7 +33,7 @@ public class IndexerDaoFactoryTest {
   @Test(expected = InstantiationException.class)
   public void failureNullType() throws Exception {
     try {
-      IndexerDaoFactory.getInstance(null, "localhost", 1234, "key", "username", "password");
+      IndexerDaoFactory.getInstance(null, "localhost", "1234", "key", "username", "password");
     } catch (InstantiationException e) {
       String msg = "[logstash-plugin]: Unknown IndexerType 'null'. Did you forget to configure the plugin?";
       assertEquals("Wrong message", msg, e.getMessage());

--- a/src/test/java/jenkins/plugins/logstash/persistence/RedisDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/RedisDaoTest.java
@@ -1,11 +1,5 @@
 package jenkins.plugins.logstash.persistence;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -13,12 +7,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RedisDaoTest {
@@ -26,14 +22,14 @@ public class RedisDaoTest {
   @Mock JedisPool mockPool;
   @Mock Jedis mockJedis;
 
-  RedisDao createDao(String host, int port, String key, String username, String password) {
+  RedisDao createDao(String host, String port, String key, String username, String password) {
     return new RedisDao(mockPool, host, port, key, username, password);
   }
 
   @Before
   public void before() throws Exception {
     int port = (int) (Math.random() * 1000);
-    dao = createDao("localhost", port, "logstash", "username", "password");
+    dao = createDao("localhost", String.valueOf(port), "logstash", "username", "password");
 
     when(mockPool.getResource()).thenReturn(mockJedis);
   }
@@ -47,7 +43,7 @@ public class RedisDaoTest {
   @Test(expected = IllegalArgumentException.class)
   public void constructorFailNullHost() throws Exception {
     try {
-      createDao(null, 6379, "logstash", "username", "password");
+      createDao(null, "6379", "logstash", "username", "password");
     } catch (IllegalArgumentException e) {
       assertEquals("Wrong error message was thrown", "host name is required", e.getMessage());
       throw e;
@@ -57,7 +53,7 @@ public class RedisDaoTest {
   @Test(expected = IllegalArgumentException.class)
   public void constructorFailEmptyHost() throws Exception {
     try {
-      createDao(" ", 6379, "logstash", "username", "password");
+      createDao(" ", "6379", "logstash", "username", "password");
     } catch (IllegalArgumentException e) {
       assertEquals("Wrong error message was thrown", "host name is required", e.getMessage());
       throw e;
@@ -67,7 +63,7 @@ public class RedisDaoTest {
   @Test(expected = IllegalArgumentException.class)
   public void constructorFailNullKey() throws Exception {
     try {
-      createDao("localhost", 6379, null, "username", "password");
+      createDao("localhost", "6379", null, "username", "password");
     } catch (IllegalArgumentException e) {
       assertEquals("Wrong error message was thrown", "redis key is required", e.getMessage());
       throw e;
@@ -77,7 +73,7 @@ public class RedisDaoTest {
   @Test(expected = IllegalArgumentException.class)
   public void constructorFailEmptyKey() throws Exception {
     try {
-      createDao("localhost", 6379, " ", "username", "password");
+      createDao("localhost", "6379", " ", "username", "password");
     } catch (IllegalArgumentException e) {
       assertEquals("Wrong error message was thrown", "redis key is required", e.getMessage());
       throw e;
@@ -87,11 +83,11 @@ public class RedisDaoTest {
   @Test
   public void constructorSuccess() throws Exception {
     // Unit under test
-    dao = createDao("localhost", 6379, "logstash", "username", "password");
+    dao = createDao("localhost", "6379", "logstash", "username", "password");
 
     // Verify results
     assertEquals("Wrong host name", "localhost", dao.host);
-    assertEquals("Wrong port", 6379, dao.port);
+    assertEquals("Wrong port", "6379", dao.port);
     assertEquals("Wrong key", "logstash", dao.key);
     assertEquals("Wrong name", "username", dao.username);
     assertEquals("Wrong password", "password", dao.password);
@@ -183,7 +179,7 @@ public class RedisDaoTest {
     String json = "{ 'foo': 'bar' }";
 
     // Initialize mocks
-    dao = createDao("localhost", 6379, "logstash", null, null);
+    dao = createDao("localhost", "6379", "logstash", null, null);
     when(mockJedis.rpush("logstash", json)).thenReturn(1L);
 
     // Unit under test


### PR DESCRIPTION
This PR contains:
- change port type from int to String to allow empty values for
  configuration
- use default port for each indexer if port is not given
- extend help text for port configuration

My use case: I want to send the data to an elasticsearch instance which is reverse-proxied by a nginx server. The plugin explicitly required a port to be set. I changed this behaviour and added default ports for each indexer backend when there is no port set.
