### PR TITLE
Add Timestamps

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.logstash.persistence;
 
+import java.util.Calendar;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
@@ -62,7 +63,8 @@ abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
     payload.put("message", logLines);
     payload.put("source", "jenkins");
     payload.put("source_host", jenkinsUrl);
-    payload.put("@timestamp", buildData.getTimestamp());
+    payload.put("@buildTimestamp", buildData.getTimestamp());
+    payload.put("@timestamp", BuildData.DATE_FORMATTER.format(Calendar.getInstance().getTime()));
     payload.put("@version", 1);
 
     return payload;

--- a/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
@@ -17,9 +17,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractLogstashIndexerDaoTest {
-  static final String EMPTY_STRING = "{\"@timestamp\":\"2000-01-01\",\"data\":{},\"message\":[],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
-  static final String ONE_LINE_STRING = "{\"@timestamp\":\"2000-01-01\",\"data\":{},\"message\":[\"LINE 1\"],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
-  static final String TWO_LINE_STRING = "{\"@timestamp\":\"2000-01-01\",\"data\":{},\"message\":[\"LINE 1\", \"LINE 2\"],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
+  static final String EMPTY_STRING = "{\"@buildTimestamp\":\"2000-01-01\",\"data\":{},\"message\":[],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
+  static final String ONE_LINE_STRING = "{\"@buildTimestamp\":\"2000-01-01\",\"data\":{},\"message\":[\"LINE 1\"],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
+  static final String TWO_LINE_STRING = "{\"@buildTimestamp\":\"2000-01-01\",\"data\":{},\"message\":[\"LINE 1\", \"LINE 2\"],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
 
   @Mock BuildData mockBuildData;
 
@@ -35,6 +35,7 @@ public class AbstractLogstashIndexerDaoTest {
 
     // Unit under test
     JSONObject result = dao.buildPayload(mockBuildData, "http://localhost:8080/jenkins", new ArrayList<String>());
+    result.remove("@timestamp");
 
     // Verify results
     assertEquals("Results don't match", JSONObject.fromObject(EMPTY_STRING), result);
@@ -46,6 +47,7 @@ public class AbstractLogstashIndexerDaoTest {
 
     // Unit under test
     JSONObject result = dao.buildPayload(mockBuildData, "http://localhost:8080/jenkins", Arrays.asList("LINE 1"));
+    result.remove("@timestamp");
 
     // Verify results
     assertEquals("Results don't match", JSONObject.fromObject(ONE_LINE_STRING), result);
@@ -57,6 +59,7 @@ public class AbstractLogstashIndexerDaoTest {
 
     // Unit under test
     JSONObject result = dao.buildPayload(mockBuildData, "http://localhost:8080/jenkins", Arrays.asList("LINE 1", "LINE 2"));
+    result.remove("@timestamp");
 
     // Verify results
     assertEquals("Results don't match", JSONObject.fromObject(TWO_LINE_STRING), result);


### PR DESCRIPTION
Move `@timestamp` to `@buildTimestamp` and make `@timestamp` the time which the log record was recorded. I tested locally that these timestamps correspond with Timestamper timestamps. If the post build action is used instead the timestamps will not match Timestamper. There are other issues with the post build action like not encapsulating the result of the job so I don't feel like the pursuit of perfection should get in the way of getting the more complete use case to work as expected.