### PR TITLE
Added support for VALO.io

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
@@ -51,6 +51,7 @@ public final class IndexerDaoFactory {
     indexerMap.put(IndexerType.REDIS, RedisDao.class);
     indexerMap.put(IndexerType.RABBIT_MQ, RabbitMqDao.class);
     indexerMap.put(IndexerType.ELASTICSEARCH, ElasticSearchDao.class);
+    indexerMap.put(IndexerType.VALO, ValoDao.class);
     indexerMap.put(IndexerType.SYSLOG, SyslogDao.class);
 
     INDEXER_MAP = Collections.unmodifiableMap(indexerMap);

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
@@ -40,7 +40,8 @@ public interface LogstashIndexerDao {
     REDIS,
     RABBIT_MQ,
     ELASTICSEARCH,
-    SYSLOG
+    SYSLOG,
+    VALO
   }
 
   String getDescription();

--- a/src/main/java/jenkins/plugins/logstash/persistence/ValoDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ValoDao.java
@@ -1,0 +1,153 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Barnes and Noble College
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins.logstash.persistence;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Valo Data Access Object.
+ *
+ * @author Paulino Padial
+ * @since 1.0.4
+ */
+public class ValoDao extends AbstractLogstashIndexerDao {
+  final HttpClientBuilder clientBuilder;
+  final URI uri;
+  final String auth;
+
+  //primary constructor used by indexer factory
+  public ValoDao(String host, int port, String key, String username, String password) {
+    this(null, host, port, key, username, password);
+  }
+
+  // Factored for unit testing
+  ValoDao(HttpClientBuilder factory, String host, int port, String key, String username, String password) {
+    super(host, port, key, username, password);
+
+    if (StringUtils.isBlank(key)) {
+      throw new IllegalArgumentException("tenant + stream uri is required");
+    }
+
+    try {
+      uri = new URIBuilder(host)
+        .setPort(port)
+        // Normalizer will remove extra starting slashes, but missing slash will cause annoying failures
+        .setPath("/streams/" + key)
+        .build();
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Could not create uri", e);
+    }
+
+    if(StringUtils.isBlank(uri.getScheme())) {
+      throw new IllegalArgumentException("host field must specify scheme, such as 'http://'");
+    }
+
+    if (StringUtils.isNotBlank(username)) {
+      auth = Base64.encodeBase64String((username + ":" + StringUtils.defaultString(password)).getBytes());
+    } else {
+      auth = null;
+    }
+
+    clientBuilder = factory == null ? HttpClientBuilder.create() : factory;
+  }
+
+  HttpPost getHttpPost(String data) {
+    HttpPost postRequest;
+    postRequest = new HttpPost(uri);
+    StringEntity input = new StringEntity(data, ContentType.APPLICATION_JSON);
+    postRequest.setEntity(input);
+    if (auth != null) {
+      postRequest.addHeader("Authorization", "Basic " + auth);
+    }
+    return postRequest;
+  }
+
+  @Override
+  public void push(String data) throws IOException {
+    CloseableHttpClient httpClient = null;
+    CloseableHttpResponse response = null;
+    HttpPost post = getHttpPost(data);
+
+    try {
+      httpClient = clientBuilder.build();
+      response = httpClient.execute(post);
+
+      if (response.getStatusLine().getStatusCode() != 201) {
+        throw new IOException(this.getErrorMessage(response));
+      }
+    } finally {
+      if (response != null) {
+        response.close();
+      }
+      if (httpClient != null) {
+        httpClient.close();
+      }
+    }
+  }
+
+  private String getErrorMessage(CloseableHttpResponse response) {
+    ByteArrayOutputStream byteStream = null;
+    PrintStream stream = null;
+    try {
+      byteStream = new ByteArrayOutputStream();
+      stream = new PrintStream(byteStream);
+
+      try {
+        stream.print("HTTP error code: ");
+        stream.println(response.getStatusLine().getStatusCode());
+        stream.print("URI: ");
+        stream.println(uri.toString());
+        stream.println("RESPONSE: " + response.toString());
+        response.getEntity().writeTo(stream);
+      } catch (IOException e) {
+        stream.println(ExceptionUtils.getStackTrace(e));
+      }
+      stream.flush();
+      return byteStream.toString();
+    } finally {
+      if (stream != null) {
+        stream.close();
+      }
+    }
+  }
+
+  @Override
+  public IndexerType getIndexerType() { return IndexerType.VALO; }
+}

--- a/src/main/java/jenkins/plugins/logstash/persistence/ValoDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ValoDao.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -98,6 +99,16 @@ public class ValoDao extends AbstractLogstashIndexerDao {
     }
     return postRequest;
   }
+  HttpPut getHttpPut(String data) {
+    HttpPut putRequest;
+    putRequest = new HttpPut(uri);
+    StringEntity input = new StringEntity(data, ContentType.APPLICATION_JSON);
+    putRequest.setEntity(input);
+    if (auth != null) {
+      putRequest.addHeader("Authorization", "Basic " + auth);
+    }
+    return putRequest;
+  }
 
   @Override
   public void push(String data) throws IOException {
@@ -109,9 +120,10 @@ public class ValoDao extends AbstractLogstashIndexerDao {
       httpClient = clientBuilder.build();
       response = httpClient.execute(post);
 
-      if (response.getStatusLine().getStatusCode() != 201) {
+      if (response.getStatusLine().getStatusCode() != 200) {
         throw new IOException(this.getErrorMessage(response));
       }
+
     } finally {
       if (response != null) {
         response.close();

--- a/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-host.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-host.html
@@ -1,4 +1,5 @@
 <div>
-  <p>The host name or IP address of the indexer to send log data to.<br>
-  ELASTICSEARCH: Also specify scheme. Example: "https://myserver". </p>
+  <br>The host name or IP address of the indexer to send log data to.<br/>
+  ELASTICSEARCH: Also specify scheme. Example: "https://myserver". <br/>
+  VALO: Also specify scheme. Example: "http://myserver".  </p>
 </div>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-key.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-key.html
@@ -1,5 +1,6 @@
 <div>
-  <p>REDIS: The name of a Redis list or channel.<br/>
+  <br>REDIS: The name of a Redis list or channel.<br/>
   RABBIT_MQ: The name of a RabbitMq queue.<br/>
-  ELASTICSEARCH: The name and type path. Example: "/indexName/type"</p>
+  ELASTICSEARCH: The name and type path. Example: "/indexName/type"</br>
+  VALO: The tenant and stream uri. Example: "tenant/collection/stream"</p>
 </div>

--- a/src/test/java/jenkins/plugins/logstash/persistence/IndexerDaoFactoryTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/IndexerDaoFactoryTest.java
@@ -11,7 +11,7 @@ public class IndexerDaoFactoryTest {
   @Test
   public void getAllInstances() throws Exception {
     for (IndexerType type : IndexerType.values()) {
-      String host = type == IndexerType.ELASTICSEARCH ? "http://localhost" : "localhost";
+      String host = (type == IndexerType.ELASTICSEARCH || type == IndexerType.VALO)  ? "http://localhost" : "localhost";
       LogstashIndexerDao dao = IndexerDaoFactory.getInstance(type, host, 1234, "key", "username", "password");
 
       assertNotNull("Result was null", dao);
@@ -22,7 +22,7 @@ public class IndexerDaoFactoryTest {
   @Test
   public void successNulls() throws Exception {
     for (IndexerType type : IndexerType.values()) {
-      String host = type == IndexerType.ELASTICSEARCH ? "http://localhost" : "localhost";
+      String host = (type == IndexerType.ELASTICSEARCH || type == IndexerType.VALO) ? "http://localhost" : "localhost";
       LogstashIndexerDao dao = IndexerDaoFactory.getInstance(type, host, null, "key", null, null);
 
       assertNotNull("Result was null", dao);

--- a/src/test/java/jenkins/plugins/logstash/persistence/ValoDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/ValoDaoTest.java
@@ -1,0 +1,203 @@
+package jenkins.plugins.logstash.persistence;
+
+import org.apache.commons.lang.CharEncoding;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ValoDaoTest {
+  ValoDao dao;
+  @Mock HttpClientBuilder mockClientBuilder;
+  @Mock CloseableHttpClient mockHttpClient;
+  @Mock StatusLine mockStatusLine;
+  @Mock CloseableHttpResponse mockResponse;
+  @Mock HttpEntity mockEntity;
+
+  ValoDao createDao(String host, int port, String key, String username, String password) {
+    return new ValoDao(mockClientBuilder, host, port, key, username, password);
+  }
+
+  @Before
+  public void before() throws Exception {
+    int port = (int) (Math.random() * 1000);
+    dao = createDao("http://localhost", port, "BUILD/ci/build", "", "");
+
+    when(mockClientBuilder.build()).thenReturn(mockHttpClient);
+    when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
+    when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+  }
+
+  @After
+  public void after() throws Exception {
+    verifyNoMoreInteractions(mockClientBuilder);
+    verifyNoMoreInteractions(mockHttpClient);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailNullHost() throws Exception {
+    try {
+      createDao(null, 8888, "BUILD/ci/build", "", "");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "host name is required", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailEmptyHost() throws Exception {
+    try {
+      createDao(" ", 8888, "BUILD/ci/build", "", "");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "host name is required", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailMissingScheme() throws Exception {
+    try {
+      createDao("localhost", 8888, "BUILD/ci/build", "", "");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "host field must specify scheme, such as 'http://'", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailNullKey() throws Exception {
+    try {
+      createDao("http://localhost", 8888, null, "", "");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "tenant + stream uri is required", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFailEmptyKey() throws Exception {
+    try {
+      createDao("http://localhost", 8888, " ", "", "");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Wrong error message was thrown", "tenant + stream uri is required", e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test
+  public void constructorSuccess1() throws Exception {
+    // Unit under test
+    dao = createDao("https://localhost", 8888, "BUILD/ci/build", "", "");
+
+    // Verify results
+    assertEquals("Wrong host name", "https://localhost", dao.host);
+    assertEquals("Wrong port", 8888, dao.port);
+    assertEquals("Wrong key", "BUILD/ci/build", dao.key);
+    assertEquals("Wrong name", "", dao.username);
+    assertEquals("Wrong password", "", dao.password);
+    assertEquals("Wrong auth", null, dao.auth); // Valo Doesnt Support auth right now
+    assertEquals("Wrong uri", new URI("https://localhost:8888/streams/BUILD/ci/build"), dao.uri);
+  }
+
+  @Test
+  public void getPostSuccessNoAuth() throws Exception {
+    String json = "{ 'foo': 'bar' }";
+    dao = createDao("http://localhost", 8888, "BUILD/ci/build", "", "");
+
+    // Unit under test
+    HttpPost post = dao.getHttpPost(json);
+    HttpEntity entity = post.getEntity();
+
+    assertEquals("Wrong uri", new URI("http://localhost:8888/streams/BUILD/ci/build") , post.getURI());
+    assertEquals("Wrong auth", 0, post.getHeaders("Authorization").length);
+    assertEquals("Wrong content type", entity.getContentType().getValue(), ContentType.APPLICATION_JSON.toString());
+    assertTrue("Wrong content class", entity instanceof StringEntity);
+
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    entity.writeTo(stream);
+    assertEquals("Wrong content", stream.toString(CharEncoding.UTF_8), "{ 'foo': 'bar' }");
+  }
+
+  @Test
+  public void getPostSuccessAuth() throws Exception {
+    String json = "{ 'foo': 'bar' }";
+    dao = createDao("https://localhost", 8888, "BUILD/ci/build", "username", "password");
+
+    // Unit under test
+    HttpPost post = dao.getHttpPost(json);
+    HttpEntity entity = post.getEntity();
+
+    assertEquals("Wrong uri", new URI("https://localhost:8888/streams/BUILD/ci/build") , post.getURI());
+    assertEquals("Wrong auth", 1, post.getHeaders("Authorization").length);
+    assertEquals("Wrong auth value", "Basic dXNlcm5hbWU6cGFzc3dvcmQ=", post.getHeaders("Authorization")[0].getValue());
+
+
+    assertEquals("Wrong content type", entity.getContentType().getValue(), ContentType.APPLICATION_JSON.toString());
+    assertTrue("Wrong content class", entity instanceof StringEntity);
+
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    entity.writeTo(stream);
+    assertEquals("Wrong content", stream.toString(CharEncoding.UTF_8), "{ 'foo': 'bar' }");
+  }
+
+  @Test
+  public void pushSuccess() throws Exception {
+    String json = "{ 'foo': 'bar' }";
+    dao = createDao("http://localhost", 8888, "BUILD/ci/build", "", "");
+
+    when(mockStatusLine.getStatusCode()).thenReturn(201);
+
+    // Unit under test
+    dao.push(json);
+
+    verify(mockClientBuilder).build();
+    verify(mockHttpClient).execute(any(HttpPost.class));
+    verify(mockStatusLine, atLeastOnce()).getStatusCode();
+    verify(mockResponse).close();
+    verify(mockHttpClient).close();
+  }
+
+  @Test(expected = IOException.class)
+  public void pushFailStatusCode() throws Exception {
+    String json = "{ 'foo': 'bar' }";
+    dao = createDao("http://localhost", 8888, "BUILD/ci/build", "username", "password");
+
+    when(mockStatusLine.getStatusCode()).thenReturn(500);
+    when(mockResponse.getEntity()).thenReturn(new StringEntity("Something bad happened.", ContentType.TEXT_PLAIN));
+
+    // Unit under test
+    try {
+      dao.push(json);
+    } catch (IOException e) {
+      // Verify results
+      verify(mockClientBuilder).build();
+      verify(mockHttpClient).execute(any(HttpPost.class));
+      verify(mockStatusLine, atLeastOnce()).getStatusCode();
+      verify(mockResponse).close();
+      verify(mockHttpClient).close();
+      assertTrue("wrong error message",
+        e.getMessage().contains("Something bad happened.") && e.getMessage().contains("HTTP error code: 500"));
+        throw e;
+    }
+
+  }
+}

--- a/src/test/java/jenkins/plugins/logstash/persistence/ValoDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/ValoDaoTest.java
@@ -164,7 +164,7 @@ public class ValoDaoTest {
     String json = "{ 'foo': 'bar' }";
     dao = createDao("http://localhost", 8888, "BUILD/ci/build", "", "");
 
-    when(mockStatusLine.getStatusCode()).thenReturn(201);
+    when(mockStatusLine.getStatusCode()).thenReturn(200);
 
     // Unit under test
     dao.push(json);


### PR DESCRIPTION
Added support for https://www.valo.io/

Currently username and password are blank. For key, you should specify TENANT/COLLECTION/STREAM_NAME.

For more information about valo, look at: https://www.valo.io/docs/
