### PR TITLE
Retrieve build data again when the slave is known

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -53,7 +53,7 @@ public class LogstashWriter {
 
   final OutputStream errorStream;
   final AbstractBuild<?, ?> build;
-  final BuildData buildData;
+  BuildData buildData;
   final String jenkinsUrl;
   final LogstashIndexerDao dao;
   private boolean connectionBroken;
@@ -81,6 +81,9 @@ public class LogstashWriter {
    *          Message, not null
    */
   public void write(String line) {
+    if (line.contains("Building remotely")) {
+      this.buildData = getBuildData();
+    }
     if (!isConnectionBroken() && StringUtils.isNotEmpty(line)) {
       this.write(Arrays.asList(line));
     }


### PR DESCRIPTION
When using the build wrapper functionality ("Send console log to Logstash" checkbox), the reported `buildHost` and `buildLabel` is `master` as the slave is not known at the time `jenkins.plugins.logstash.LogstashWriter#buildData` is initialized.

This PR checks if current line contains "Building remotely" and retrieves buildData again, to have it filled with slave data.

This might be not an abstracted configurable solution, but it works for us. Maybe someone has an idea how to make this generally useful. Maybe retrieve `buildData` every time a line is logged?
