### PR TITLE
Add verbose information about Syslog format

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently supported methods of input/output:
 * ElasticSearch {REST API}
 * Redis {format => 'json_event'}
 * RabbitMQ {mechanism => PLAIN}
-* Syslog {format => cee/json, protocol => UDP}
+* Syslog {format => cee/json (based on RFC_5424, not viable for logstash syslog input), protocol => UDP}
 
 License
 =======

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently supported methods of input/output:
 * ElasticSearch {REST API}
 * Redis {format => 'json_event'}
 * RabbitMQ {mechanism => PLAIN}
-* Syslog {format => cee/json (based on RFC_5424, not viable for logstash syslog input), protocol => UDP}
+* Syslog {format => cee/json ([RFC-5424](https://tools.ietf.org/html/rfc5424), not viable for logstash syslog input), protocol => UDP}
 
 License
 =======


### PR DESCRIPTION
Becuase Logstash syslog input only supports RFC_3164 Syslog can not be used to send directly to logstash.