### PR TITLE
Indexer syslog tcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Currently supported methods of input/output:
 * Redis {format => 'json_event'}
 * RabbitMQ {mechanism => PLAIN}
 * Syslog {format => cee/json, protocol => UDP}
+* SyslogTCP {format => cee/json, protocol => TCP}
 
 License
 =======

--- a/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
@@ -52,6 +52,7 @@ public final class IndexerDaoFactory {
     indexerMap.put(IndexerType.RABBIT_MQ, RabbitMqDao.class);
     indexerMap.put(IndexerType.ELASTICSEARCH, ElasticSearchDao.class);
     indexerMap.put(IndexerType.SYSLOG, SyslogDao.class);
+    indexerMap.put(IndexerType.SYSLOGTCP, SyslogTCPDao.class);
 
     INDEXER_MAP = Collections.unmodifiableMap(indexerMap);
   }

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
@@ -40,7 +40,8 @@ public interface LogstashIndexerDao {
     REDIS,
     RABBIT_MQ,
     ELASTICSEARCH,
-    SYSLOG
+    SYSLOG,
+    SYSLOGTCP
   }
 
   String getDescription();

--- a/src/main/java/jenkins/plugins/logstash/persistence/SyslogTCPDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/SyslogTCPDao.java
@@ -1,0 +1,42 @@
+package jenkins.plugins.logstash.persistence;
+
+import com.cloudbees.syslog.sender.TcpSyslogMessageSender;
+import com.cloudbees.syslog.Facility;
+import com.cloudbees.syslog.MessageFormat;
+import com.cloudbees.syslog.Severity;
+import java.io.IOException;
+
+
+public class SyslogDao extends AbstractLogstashIndexerDao {
+  final TcpSyslogMessageSender messageSender;
+  
+  public SyslogDao(String host, int port, String key, String username, String password) {
+    this(null, host, port, key, username, password);
+  }
+
+  public SyslogDao(TcpSyslogMessageSender tcpSyslogMessageSender, String host, int port, String key, String username, String password) {
+    super(host, port, key, username, password);
+    messageSender = tcpSyslogMessageSender == null ? new TcpSyslogMessageSender() : tcpSyslogMessageSender;
+  }
+
+  @Override
+  public void push(String data) throws IOException {
+    // Making the JSON document compliant to Common Event Expression (CEE)
+    // http://www.rsyslog.com/json-elasticsearch/
+    data = " @cee: "  + data;
+    // SYSLOGTCP Configuration
+    messageSender.setDefaultMessageHostname(host);
+    messageSender.setDefaultAppName("jenkins:");
+    messageSender.setDefaultFacility(Facility.USER);
+    messageSender.setDefaultSeverity(Severity.INFORMATIONAL);
+    messageSender.setSyslogServerHostname(host);
+    messageSender.setSyslogServerPort(port);
+    messageSender.setMessageFormat(MessageFormat.RFC_5424);
+    messageSender.setSsl(false);
+    // Sending the message
+    messageSender.sendMessage(data);
+  }
+
+  @Override
+  public IndexerType getIndexerType() { return IndexerType.SYSLOGTCP; }
+}

--- a/src/main/java/jenkins/plugins/logstash/persistence/SyslogTCPDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/SyslogTCPDao.java
@@ -7,14 +7,14 @@ import com.cloudbees.syslog.Severity;
 import java.io.IOException;
 
 
-public class SyslogDao extends AbstractLogstashIndexerDao {
+public class SyslogTCPDao extends AbstractLogstashIndexerDao {
   final TcpSyslogMessageSender messageSender;
   
-  public SyslogDao(String host, int port, String key, String username, String password) {
+  public SyslogTCPDao(String host, int port, String key, String username, String password) {
     this(null, host, port, key, username, password);
   }
 
-  public SyslogDao(TcpSyslogMessageSender tcpSyslogMessageSender, String host, int port, String key, String username, String password) {
+  public SyslogTCPDao(TcpSyslogMessageSender tcpSyslogMessageSender, String host, int port, String key, String username, String password) {
     super(host, port, key, username, password);
     messageSender = tcpSyslogMessageSender == null ? new TcpSyslogMessageSender() : tcpSyslogMessageSender;
   }

--- a/src/test/java/jenkins/plugins/logstash/persistence/SyslogTCPDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/SyslogTCPDaoTest.java
@@ -1,0 +1,67 @@
+package jenkins.plugins.logstash.persistence;
+
+import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import com.cloudbees.syslog.Facility;
+import com.cloudbees.syslog.MessageFormat;
+import com.cloudbees.syslog.Severity;
+import com.cloudbees.syslog.sender.TcpSyslogMessageSender;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class SyslogTCPDaoTest {
+  SyslogTCPDao dao;
+  String data = "{ 'junit': 'SyslogTCPDaoTest' }";
+  String host = "localhost";
+  String appname = "jenkins:";
+  int port = 514;
+  TcpSyslogMessageSender testSyslogSend = new TcpSyslogMessageSender();
+  @Mock TcpSyslogMessageSender mockTcpSyslogMessageSender;
+ 	  
+  @Before
+  public void before() throws Exception {    
+    dao = createDao(host, port, null, null, null);
+    dao.push(data); 
+  }
+
+  // Test the Message format.
+  @Test
+  public void ceeMessageFormat() throws Exception {
+    verify(mockTcpSyslogMessageSender, times(1)).sendMessage(" @cee: " + data);
+  }
+
+  // Test the MessageSender configuration. 
+  @Test
+  public void syslogConfig() throws Exception {
+    verify(mockTcpSyslogMessageSender, times(1)).setDefaultMessageHostname(host);
+    verify(mockTcpSyslogMessageSender, times(1)).setDefaultAppName(appname);
+    verify(mockTcpSyslogMessageSender, times(1)).setSyslogServerHostname(host);
+    verify(mockTcpSyslogMessageSender, times(1)).setSyslogServerPort(port);
+    verify(mockTcpSyslogMessageSender, times(1)).setDefaultFacility(Facility.USER);
+    verify(mockTcpSyslogMessageSender, times(1)).setDefaultSeverity(Severity.INFORMATIONAL);
+    verify(mockTcpSyslogMessageSender, times(1)).setMessageFormat(MessageFormat.RFC_5424);
+    verify(mockTcpSyslogMessageSender, times(1)).setSsl(false);
+  }
+
+  // Send a real Syslog message.
+  @Test
+  public void syslogSend() throws Exception {
+    testSyslogSend.setDefaultMessageHostname(host);
+    testSyslogSend.setDefaultAppName(appname);
+    testSyslogSend.setSyslogServerHostname(host);
+    testSyslogSend.setSyslogServerPort(port);
+    testSyslogSend.setDefaultFacility(Facility.USER);
+    testSyslogSend.setDefaultSeverity(Severity.INFORMATIONAL);
+    testSyslogSend.setMessageFormat(MessageFormat.RFC_5424);  
+    testSyslogSend.setSsl(false);
+    testSyslogSend.sendMessage(" @cee: " + data);
+  }
+  
+  SyslogTCPDao createDao(String host, int port, String key, String username, String password) {
+    return new SyslogTCPDao(mockTcpSyslogMessageSender, host, port, key, username, password);
+  }
+}


### PR DESCRIPTION
Adds indexer support for syslog over TCP.  The primary driver for this is to support highly available logstash instances behind a load balancer.

- does not support SSL