### PR TITLE
Full project name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.1.0</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.logstash.persistence;
 
+
 import hudson.model.Action;
 import hudson.model.Environment;
 import hudson.model.Result;
@@ -48,16 +49,15 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.WARNING;
-
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 
 
 /**
@@ -106,11 +106,11 @@ public class BuildData {
       skipCount = testResultAction.getSkipCount();
       failCount = testResultAction.getFailCount();
       passCount = totalCount - skipCount - failCount;
- 
+
       failedTests = new ArrayList<String>();
       failedTestsWithErrorDetail = new ArrayList<FailedTest>();
       for (TestResult result : testResultAction.getFailedTests()) {
-    	  failedTests.add(result.getFullName());  
+          failedTests.add(result.getFullName());
           failedTestsWithErrorDetail.add(new FailedTest(result.getFullName(),result.getErrorDetails()));
       }
     }
@@ -136,8 +136,6 @@ public class BuildData {
   protected Map<String, String> buildVariables;
   protected Set<String> sensitiveBuildVariables;
   protected TestData testResults = null;
-
-  BuildData() {}
 
   // Freestyle project build
   public BuildData(AbstractBuild<?, ?> build, Date currentTime, TaskListener listener) {

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -24,7 +24,6 @@
 
 package jenkins.plugins.logstash.persistence;
 
-
 import hudson.model.Action;
 import hudson.model.Environment;
 import hudson.model.Result;
@@ -57,8 +56,6 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
-
 
 /**
  * POJO for mapping build info to JSON.

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -59,6 +59,7 @@ import org.apache.commons.lang.StringUtils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+
 /**
  * POJO for mapping build info to JSON.
  *
@@ -118,6 +119,7 @@ public class BuildData {
   protected String id;
   protected String result;
   protected String projectName;
+  protected String fullProjectName;
   protected String displayName;
   protected String fullDisplayName;
   protected String description;
@@ -128,6 +130,7 @@ public class BuildData {
   protected long buildDuration;
   protected transient String timestamp; // This belongs in the root object
   protected String rootProjectName;
+  protected String rootFullProjectName;
   protected String rootProjectDisplayName;
   protected int rootBuildNum;
   protected Map<String, String> buildVariables;
@@ -151,6 +154,7 @@ public class BuildData {
 
     // build.getDuration() is always 0 in Notifiers
     rootProjectName = build.getRootBuild().getProject().getName();
+    rootFullProjectName = build.getRootBuild().getProject().getFullName();
     rootProjectDisplayName = build.getRootBuild().getDisplayName();
     rootBuildNum = build.getRootBuild().getNumber();
     buildVariables = build.getBuildVariables();
@@ -195,6 +199,7 @@ public class BuildData {
     }
 
     rootProjectName = projectName;
+    rootFullProjectName = fullProjectName;
     rootProjectDisplayName = displayName;
     rootBuildNum = buildNum;
 
@@ -211,6 +216,7 @@ public class BuildData {
     result = build.getResult() == null ? null : build.getResult().toString();
     id = build.getId();
     projectName = build.getParent().getName();
+    fullProjectName = build.getParent().getFullName();
     displayName = build.getDisplayName();
     fullDisplayName = build.getFullDisplayName();
     description = build.getDescription();
@@ -259,6 +265,14 @@ public class BuildData {
 
   public void setProjectName(String projectName) {
     this.projectName = projectName;
+  }
+
+  public String getFullProjectName() {
+    return fullProjectName;
+  }
+
+  public void setFullProjectName(String fullProjectName) {
+    this.fullProjectName = fullProjectName;
   }
 
   public String getDisplayName() {
@@ -339,6 +353,14 @@ public class BuildData {
 
   public void setRootProjectName(String rootProjectName) {
     this.rootProjectName = rootProjectName;
+  }
+
+  public String getRootFullProjectName() {
+    return rootFullProjectName;
+  }
+
+  public void setRootFullProjectName(String rootFullProjectName) {
+    this.rootFullProjectName = rootFullProjectName;
   }
 
   public String getRootProjectDisplayName() {

--- a/src/test/java/jenkins/plugins/logstash/LogstashNotifierTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashNotifierTest.java
@@ -87,7 +87,6 @@ public class LogstashNotifierTest {
     errorBuffer = new ByteArrayOutputStream();
     errorStream = new PrintStream(errorBuffer, true);
 
-    when(mockBuild.getLog(anyInt())).thenReturn(Arrays.asList("line 1", "line 2", "line 3"));
     mockRun = new MockRun(mock(AbstractProject.class));
 
     when(mockListener.getLogger()).thenReturn(errorStream);

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -84,9 +84,9 @@ public class LogstashWriterTest {
     when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
     when(mockBuild.getDisplayName()).thenReturn("LogstashNotifierTest");
     when(mockBuild.getProject()).thenReturn(mockProject);
+    when(mockBuild.getParent()).thenReturn(mockProject);
     when(mockBuild.getBuiltOn()).thenReturn(null);
     when(mockBuild.getNumber()).thenReturn(123456);
-    when(mockBuild.getDuration()).thenReturn(0L);
     when(mockBuild.getTimestamp()).thenReturn(new GregorianCalendar());
     when(mockBuild.getRootBuild()).thenReturn(mockBuild);
     when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
@@ -104,6 +104,7 @@ public class LogstashWriterTest {
     when(mockTestResultAction.getFailedTests()).thenReturn(Collections.emptyList());
 
     when(mockProject.getName()).thenReturn("LogstashWriterTest");
+    when(mockProject.getFullName()).thenReturn("parent/LogstashWriterTest");
 
     when(mockDao.buildPayload(Matchers.any(BuildData.class), Matchers.anyString(), Matchers.anyListOf(String.class)))
       .thenReturn(JSONObject.fromObject("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}"));
@@ -134,6 +135,8 @@ public class LogstashWriterTest {
     verify(mockBuild).getId();
     verify(mockBuild, times(2)).getResult();
     verify(mockBuild, times(2)).getParent();
+    verify(mockBuild, times(2)).getProject();
+    verify(mockBuild, times(1)).getStartTimeInMillis();
     verify(mockBuild, times(2)).getDisplayName();
     verify(mockBuild).getFullDisplayName();
     verify(mockBuild).getDescription();
@@ -142,7 +145,7 @@ public class LogstashWriterTest {
     verify(mockBuild).getBuiltOn();
     verify(mockBuild, times(2)).getNumber();
     verify(mockBuild).getTimestamp();
-    verify(mockBuild, times(3)).getRootBuild();
+    verify(mockBuild, times(4)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getSensitiveBuildVariables();
     verify(mockBuild).getEnvironments();
@@ -154,6 +157,7 @@ public class LogstashWriterTest {
     verify(mockTestResultAction, times(1)).getFailedTests();
 
     verify(mockProject, times(2)).getName();
+    verify(mockProject, times(2)).getFullName();
 
     // Verify results
     assertEquals("Results don't match", "", errorBuffer.toString());

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -80,6 +80,7 @@ public class BuildDataTest {
     when(mockBuild.getAction(AbstractTestResultAction.class)).thenReturn(mockTestResultAction);
     when(mockBuild.getEnvironment(mockListener)).thenReturn(new EnvVars());
     when(mockBuild.getRootBuild()).thenReturn(mockRootBuild);
+
     when(mockTestResultAction.getTotalCount()).thenReturn(0);
     when(mockTestResultAction.getSkipCount()).thenReturn(0);
     when(mockTestResultAction.getFailCount()).thenReturn(0);
@@ -87,9 +88,11 @@ public class BuildDataTest {
 
     when(mockProject.getName()).thenReturn("BuildDataTest");
     when(mockProject.getFullName()).thenReturn("parent/BuildDataTest");
+
     when(mockRootBuild.getProject()).thenReturn(mockRootProject);
     when(mockRootBuild.getNumber()).thenReturn(456);
     when(mockRootBuild.getDisplayName()).thenReturn("Root BuildData Test");
+
     when(mockRootProject.getName()).thenReturn("RootBuildDataTest");
     when(mockRootProject.getFullName()).thenReturn("parent/RootBuildDataTest");
 
@@ -105,7 +108,6 @@ public class BuildDataTest {
     verifyNoMoreInteractions(mockDate);
     verifyNoMoreInteractions(mockRootBuild);
     verifyNoMoreInteractions(mockRootProject);
-
   }
 
   private void verifyMocks() throws Exception

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -45,7 +45,7 @@ import net.sf.json.test.JSONAssert;
 @RunWith(MockitoJUnitRunner.class)
 public class BuildDataTest {
 
-  static final String FULL_STRING = "{\"id\":\"TEST_JOB_123\",\"result\":\"SUCCESS\",\"projectName\":\"PROJECT_NAME\",\"displayName\":\"DISPLAY NAME\",\"fullDisplayName\":\"FULL DISPLAY NAME\",\"description\":\"DESCRIPTION\",\"url\":\"http://localhost:8080/jenkins/jobs/PROJECT_NAME/123\",\"buildHost\":\"http://localhost:8080/jenkins\",\"buildLabel\":\"master\",\"buildNum\":123,\"buildDuration\":100,\"rootProjectName\":\"ROOT PROJECT NAME\",\"rootProjectDisplayName\":\"ROOT PROJECT DISPLAY NAME\",\"rootBuildNum\":456,\"buildVariables\":{},\"sensitiveBuildVariables\":[],\"testResults\":{\"totalCount\":0,\"skipCount\":0,\"failCount\":0, \"passCount\":0,\"failedTests\":[], \"failedTestsWithErrorDetail\":[]}}";
+  static final String FULL_STRING = "{\"id\":\"TEST_JOB_123\",\"result\":\"SUCCESS\",\"fullProjectName\":\"full/PROJECT_NAME\",\"projectName\":\"PROJECT_NAME\",\"displayName\":\"DISPLAY NAME\",\"fullDisplayName\":\"FULL DISPLAY NAME\",\"description\":\"DESCRIPTION\",\"url\":\"http://localhost:8080/jenkins/jobs/PROJECT_NAME/123\",\"buildHost\":\"http://localhost:8080/jenkins\",\"buildLabel\":\"master\",\"buildNum\":123,\"buildDuration\":100,\"rootProjectName\":\"ROOT PROJECT NAME\",\"rootFullProjectName\":\"full/ROOT PROJECT NAME\",\"rootProjectDisplayName\":\"ROOT PROJECT DISPLAY NAME\",\"rootBuildNum\":456,\"buildVariables\":{},\"sensitiveBuildVariables\":[],\"testResults\":{\"totalCount\":0,\"skipCount\":0,\"failCount\":0, \"passCount\":0,\"failedTests\":[], \"failedTestsWithErrorDetail\":[]}}";
 
   @Mock AbstractBuild mockBuild;
   @Mock AbstractTestResultAction mockTestResultAction;
@@ -334,10 +334,12 @@ public class BuildDataTest {
     buildData.setFullDisplayName("FULL DISPLAY NAME");
     buildData.setId("TEST_JOB_123");
     buildData.setProjectName("PROJECT_NAME");
+    buildData.setFullProjectName("full/PROJECT_NAME");
     buildData.setResult(Result.SUCCESS);
     buildData.setRootBuildNum(456);
     buildData.setRootProjectDisplayName("ROOT PROJECT DISPLAY NAME");
     buildData.setRootProjectName("ROOT PROJECT NAME");
+    buildData.setRootFullProjectName("full/ROOT PROJECT NAME");
     buildData.timestamp = "2000-02-01T00:00:00-0800";
     buildData.setUrl("http://localhost:8080/jenkins/jobs/PROJECT_NAME/123");
     buildData.setTestResults(new TestData());

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -346,4 +346,32 @@ public class BuildDataTest {
       verifyMocks();
       verifyTestResultActions();
   }
+
+  @Test
+  public void fullName() throws Exception
+  {
+      when(mockBuild.getId()).thenReturn("TEST_JOB_123");
+      when(mockBuild.getUrl()).thenReturn("http://localhost:8080/jenkins/jobs/PROJECT_NAME/123");
+
+      BuildData buildData = new BuildData(mockBuild, mockDate, mockListener);
+
+      Assert.assertEquals(buildData.getFullProjectName(), "parent/BuildDataTest");
+
+      verifyMocks();
+      verifyTestResultActions();
+  }
+
+  @Test
+  public void rootProjectFullName() throws Exception
+  {
+      when(mockBuild.getId()).thenReturn("TEST_JOB_123");
+      when(mockBuild.getUrl()).thenReturn("http://localhost:8080/jenkins/jobs/PROJECT_NAME/123");
+
+      BuildData buildData = new BuildData(mockBuild, mockDate, mockListener);
+
+      Assert.assertEquals(buildData.getRootFullProjectName(), "parent/RootBuildDataTest");
+
+      verifyMocks();
+      verifyTestResultActions();
+  }
 }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
When folders are installed the projectName alone might not be unique anymore. So we should also expose the fullProjectName and rootFullProjectName.