### PR TITLE
support custom log lines processing via script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.37-SNAPSHOT</version>
+      <version>1.37</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,14 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <skipIntegrationTests>true</skipIntegrationTests>
+    <jenkins.version>2.7.3</jenkins.version>
+    <java.level>7</java.level>
   </properties>
   
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.599</version>
+    <version>2.9</version>
   </parent>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
+		<repository>
+        <!-- FIXME remove! -->
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>    
   </repositories>
 
   <pluginRepositories>
@@ -130,9 +135,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>script-security</artifactId>
-      <version>1.37</version>
+        <groupId>com.github.akostadinov</groupId>
+        <artifactId>script-security-plugin</artifactId>
+        <version>master-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mask-passwords</artifactId>
       <version>2.8</version>
-      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.1.0</version>
+      <version>2.13.0</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,19 @@
       <artifactId>structs</artifactId>
       <version>1.2</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.37-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>1.0.0.GA</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
@@ -32,13 +32,19 @@ import hudson.model.AbstractProject;
 import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.CheckForNull;
+
+import groovy.lang.Binding;
+
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper;
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarPasswordPair;
@@ -46,17 +52,25 @@ import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsConfig;
 
 /**
  * Build wrapper that decorates the build's logger to insert a
- * {@link LogstashNote} on each output line.
+ * Logstash note on each output line.
  *
  * @author K Jonathan Harker
  */
 public class LogstashBuildWrapper extends BuildWrapper {
+
+  @CheckForNull
+  private SecureGroovyScript secureGroovyScript;
 
   /**
    * Create a new {@link LogstashBuildWrapper}.
    */
   @DataBoundConstructor
   public LogstashBuildWrapper() {}
+
+  @DataBoundSetter
+  public void setSecureGroovyScript(@CheckForNull SecureGroovyScript script) {
+    this.secureGroovyScript = script != null ? script.configuringWithNonKeyItem() : null;
+  }
 
   /**
    * {@inheritDoc}
@@ -106,9 +120,18 @@ public class LogstashBuildWrapper extends BuildWrapper {
     return (DescriptorImpl) super.getDescriptor();
   }
 
+  public SecureGroovyScript getSecureGroovyScript() {
+    return secureGroovyScript;
+  }
+
   // Method to encapsulate calls for unit-testing
   LogstashWriter getLogStashWriter(AbstractBuild<?, ?> build, OutputStream errorStream) {
-    return new LogstashWriter(build, errorStream, null);
+    LogstashScriptProcessor processor = null;
+    if (secureGroovyScript != null) {
+      processor = new LogstashScriptProcessor(secureGroovyScript, errorStream);
+    }
+
+    return new LogstashWriter(build, errorStream, null, processor);
   }
 
   /**

--- a/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
@@ -120,6 +120,7 @@ public class LogstashBuildWrapper extends BuildWrapper {
     return (DescriptorImpl) super.getDescriptor();
   }
 
+  @CheckForNull
   public SecureGroovyScript getSecureGroovyScript() {
     return secureGroovyScript;
   }

--- a/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
@@ -43,6 +43,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * POJO for storing global configurations shared between components.
  *
@@ -65,6 +67,9 @@ public class LogstashInstallation extends ToolInstallation {
   public static final class Descriptor extends ToolDescriptor<LogstashInstallation> {
     public IndexerType type;
     public SyslogFormat syslogFormat;
+    @SuppressFBWarnings(
+      value="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD",
+      justification="TODO: do we need this?")
     public SyslogProtocol syslogProtocol;
     public String host;
     public Integer port = -1;
@@ -85,6 +90,9 @@ public class LogstashInstallation extends ToolInstallation {
     }
 
     @Override
+    @SuppressFBWarnings(
+      value="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+      justification="TODO: investigate")
     public ToolInstallation newInstance(StaplerRequest req, JSONObject formData) throws FormException {
       req.bindJSON(this, formData.getJSONObject("logstash"));
       save();

--- a/src/main/java/jenkins/plugins/logstash/LogstashOutputStream.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashOutputStream.java
@@ -35,6 +35,8 @@ import java.util.List;
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarPasswordPair;
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsOutputStream;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Output stream that writes each line to the provided delegate output stream
  * and also sends it to an indexer for logstash to consume.
@@ -61,6 +63,9 @@ public class LogstashOutputStream extends LineTransformationOutputStream {
   }
 
   @Override
+  @SuppressFBWarnings(
+    value="DM_DEFAULT_ENCODING",
+    justification="TODO: not sure how to fix this")
   protected void eol(byte[] b, int len) throws IOException {
     delegate.write(b, 0, len);
     this.flush();
@@ -86,6 +91,7 @@ public class LogstashOutputStream extends LineTransformationOutputStream {
    */
   @Override
   public void close() throws IOException {
+    logstash.close();
     delegate.close();
     super.close();
   }

--- a/src/main/java/jenkins/plugins/logstash/LogstashPayloadProcessor.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashPayloadProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Red Hat inc, and individual contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins.logstash;
+
+import net.sf.json.JSONObject;
+
+/**
+ * Interface describing processors of persisted payload.
+ *
+ * @author Aleksandar Kostadinov
+ * @since 1.4.0
+ */
+public interface LogstashPayloadProcessor {
+  /**
+   * Modifies a JSON payload compatible with the Logstash schema.
+   *
+   * @param payload the JSON payload that has been constructed so far.
+   * @return The formatted JSON object, can be null to ignore this payload.
+   */
+  JSONObject process(JSONObject payload) throws Exception;
+
+  /**
+   * Finalizes any operations, for example returns cashed lines at end of build.
+   *
+   * @return A formatted JSON object, can be null when it has nothing.
+   */
+  JSONObject finish() throws Exception;
+}

--- a/src/main/java/jenkins/plugins/logstash/LogstashScriptProcessor.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashScriptProcessor.java
@@ -1,0 +1,140 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Red Hat inc. and individual contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins.logstash;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.LinkedHashMap;
+
+import javax.annotation.Nonnull;
+
+import groovy.lang.Binding;
+
+import net.sf.json.JSONObject;
+
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * This class is handling custom groovy script processing of JSON payload.
+ * Each call to process executes the script provided in job configuration.
+ * Script is executed under the same binding each time so that it has ability
+ * to persist data during build execution if desired by script author.
+ * When build is finished, script will receive null as the payload and can
+ * return any cached but non-sent data back for persisting.
+ * The return value of script is the payload to be persisted unless null.
+ *
+ * @author Aleksandar Kostadinov
+ * @since 1.4.0
+ */
+public class LogstashScriptProcessor implements LogstashPayloadProcessor{
+  @Nonnull
+  private final SecureGroovyScript script;
+
+  @Nonnull
+  private final OutputStream consoleOut;
+
+  /** Groovy binding for script execution */
+  @Nonnull
+  private final Binding binding;
+
+  /** Classloader for script execution */
+  @Nonnull
+  private final ClassLoader classLoader;
+
+  /** Script prepared for execution */
+  @Nonnull
+  private final SecureGroovyScript.PreparedScript preparedScript;
+
+  public LogstashScriptProcessor(SecureGroovyScript script, OutputStream consoleOut) {
+    this.script = script;
+    this.consoleOut = consoleOut;
+
+    // TODO: should we put variables in the binding like manager, job, etc.?
+    binding = new Binding();
+    binding.setVariable("console", new BuildConsoleWrapper());
+
+    // not sure what the diff is compared to getClass().getClassLoader();
+    final Jenkins jenkins = Jenkins.getInstance();
+    classLoader = jenkins.getPluginManager().uberClassLoader;
+    try {
+      preparedScript = script.prepare(classLoader, binding);
+    } catch (Exception e) {
+      throw new RuntimeException("Error preparing log processor groovy script.", e);
+    }
+  }
+
+  /**
+   * Helper method to allow logging to build console.
+   */
+  @SuppressFBWarnings(
+    value="DM_DEFAULT_ENCODING",
+    justification="TODO: not sure how to fix this")
+  private void buildLogPrintln(Object o) throws IOException {
+    consoleOut.write(o.toString().getBytes());
+    consoleOut.write("\n".getBytes());
+    consoleOut.flush();
+  }
+
+  /*
+   * good examples in:
+   *  https://github.com/jenkinsci/envinject-plugin/blob/master/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectEnvVars.java
+   *  https://github.com/jenkinsci/groovy-postbuild-plugin/pull/11/files
+   */
+  @Override
+  public JSONObject process(JSONObject payload) throws Exception {
+    binding.setVariable("payload", payload);
+    preparedScript.run();
+    Object processedPayload = binding.getVariable("payload");
+    if (processedPayload != null && !(processedPayload instanceof JSONObject)) {
+      throw new ClassCastException("script returned " + processedPayload.getClass().getName() + " instead of JSONObject");
+    }
+    return (JSONObject) processedPayload;
+  }
+
+  @Override
+  public JSONObject finish() throws Exception {
+    try {
+      buildLogPrintln("Tearing down Script Log Processor..");
+      return process(null);
+    } finally {
+      preparedScript.cleanUp();
+    }
+  }
+
+  /**
+   * Helper to allow access from sandboxed script to output messages to console.
+   */
+  private class BuildConsoleWrapper {
+    @Whitelisted
+    public void println(Object o) throws IOException {
+      buildLogPrintln(o);
+    }
+  }
+}

--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -36,11 +36,14 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * A writer that wraps all Logstash DAOs.  Handles error reporting and per build connection state.
@@ -49,6 +52,7 @@ import java.util.List;
  *
  * @author Rusty Gerard
  * @author Liam Newman
+ * @author Aleksandar Kostadinov
  * @since 1.0.5
  */
 public class LogstashWriter {
@@ -61,10 +65,18 @@ public class LogstashWriter {
   final LogstashIndexerDao dao;
   private boolean connectionBroken;
 
+  @CheckForNull
+  private final LogstashPayloadProcessor payloadProcessor;
+
   public LogstashWriter(Run<?, ?> run, OutputStream error, TaskListener listener) {
+    this(run, error, listener, null);
+  }
+
+  public LogstashWriter(Run<?, ?> run, OutputStream error, TaskListener listener, LogstashPayloadProcessor payloadProcessor) {
     this.errorStream = error != null ? error : System.err;
     this.build = run;
     this.listener = listener;
+    this.payloadProcessor = payloadProcessor;
     this.dao = this.getDaoOrNull();
     if (this.dao == null) {
       this.jenkinsUrl = "";
@@ -149,7 +161,35 @@ public class LogstashWriter {
    * Write a list of lines to the indexer as one Logstash payload.
    */
   private void write(List<String> lines) {
-    JSONObject payload = dao.buildPayload(buildData, jenkinsUrl, lines);
+    write(dao.buildPayload(buildData, jenkinsUrl, lines));
+  }
+
+  /**
+   * Write JSONObject payload to the Logstash indexer.
+   * @since 1.0.5
+   */
+  private void write(JSONObject payload) {
+    if (payloadProcessor != null) {
+      JSONObject processedPayload = payload;
+      try {
+        processedPayload = payloadProcessor.process(payload);
+      } catch (Exception e) {
+        String msg =  ExceptionUtils.getMessage(e) + "\n" +
+          "[logstash-plugin]: Error in payload processing.\n";
+
+        logErrorMessage(msg);
+      }
+      if (processedPayload != null) { writeRaw(processedPayload); }
+    } else {
+      writeRaw(payload);
+    }
+  }
+
+  /**
+   * Write JSONObject payload to the Logstash indexer.
+   * @since 1.0.5
+   */
+  private void writeRaw(JSONObject payload) {
     try {
       dao.push(payload.toString());
     } catch (IOException e) {
@@ -181,6 +221,9 @@ public class LogstashWriter {
   /**
    * Write error message to errorStream and set connectionBroken to true.
    */
+  @SuppressFBWarnings(
+    value="DM_DEFAULT_ENCODING",
+    justification="TODO: not sure how to fix this")
   private void logErrorMessage(String msg) {
     try {
       connectionBroken = true;
@@ -189,6 +232,25 @@ public class LogstashWriter {
     } catch (IOException ex) {
       // This should never happen, but if it does we just have to let it go.
       ex.printStackTrace();
+    }
+  }
+
+  /**
+   * Signal payload processor that there will be no more lines
+   */
+  public void close() {
+    if (payloadProcessor != null) {
+      JSONObject payload = null;
+      try {
+        // calling finish() is mandatory to avoid memory leaks
+        payload = payloadProcessor.finish();
+      } catch (Exception e) {
+        String msg =  ExceptionUtils.getMessage(e) + "\n" +
+          "[logstash-plugin]: Error with payload processor on finish.\n";
+
+        logErrorMessage(msg);
+      }
+      if (payload != null) writeRaw(payload);
     }
   }
 }

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -31,6 +31,8 @@ import org.apache.commons.lang.StringUtils;
 
 import net.sf.json.JSONObject;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Abstract data access object for Logstash indexers.
  *
@@ -57,6 +59,9 @@ abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
   }
 
   @Override
+  @SuppressFBWarnings(
+    value="STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE",
+    justification="TODO: not sure how to fix this")
   public JSONObject buildPayload(BuildData buildData, String jenkinsUrl, List<String> logLines) {
     JSONObject payload = new JSONObject();
     payload.put("data", buildData.toJson());

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -24,7 +24,7 @@
 
 package jenkins.plugins.logstash.persistence;
 
-import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
@@ -59,9 +59,6 @@ abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
   }
 
   @Override
-  @SuppressFBWarnings(
-    value="STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE",
-    justification="TODO: not sure how to fix this")
   public JSONObject buildPayload(BuildData buildData, String jenkinsUrl, List<String> logLines) {
     JSONObject payload = new JSONObject();
     payload.put("data", buildData.toJson());
@@ -69,7 +66,7 @@ abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
     payload.put("source", "jenkins");
     payload.put("source_host", jenkinsUrl);
     payload.put("@buildTimestamp", buildData.getTimestamp());
-    payload.put("@timestamp", BuildData.DATE_FORMATTER.format(Calendar.getInstance().getTime()));
+    payload.put("@timestamp", BuildData.formatDateIso(new Date()));
     payload.put("@version", 1);
 
     return payload;

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -51,8 +51,10 @@ import static java.util.logging.Level.WARNING;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import net.sf.json.JSONObject;
+import javax.annotation.CheckForNull;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.time.FastDateFormat;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -66,11 +68,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @since 1.0.0
  */
 public class BuildData {
-  // ISO 8601 date format
-  @SuppressFBWarnings(
-    value="STCAL_STATIC_SIMPLE_DATE_FORMAT_INSTANCE",
-    justification="TODO: not sure how to fix this")
-  public transient static final DateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+  private transient static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ");
   private final static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getCanonicalName());
   public static class TestData {
     int totalCount, skipCount, failCount, passCount;
@@ -121,8 +119,8 @@ public class BuildData {
     }
   }
 
+  @CheckForNull protected String result;
   protected String id;
-  protected String result;
   protected String projectName;
   protected String fullProjectName;
   protected String displayName;
@@ -215,11 +213,14 @@ public class BuildData {
     }
   }
 
-  @SuppressFBWarnings(
-    value={"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE","STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE"},
-    justification="TODO: not sure how to fix this")
+  // ISO 8601 date format
+  public static String formatDateIso(Date date) {
+    return DATE_FORMATTER.format(date);
+  }
+
   private void initData(Run<?, ?> build, Date currentTime) {
-    result = build.getResult() == null ? null : build.getResult().toString();
+    Result buildResult = build.getResult();
+    result = buildResult == null ? null : buildResult.toString();
     id = build.getId();
     projectName = build.getParent().getName();
     fullProjectName = build.getParent().getFullName();
@@ -235,7 +236,7 @@ public class BuildData {
     }
 
     buildDuration = currentTime.getTime() - build.getStartTimeInMillis();
-    timestamp = DATE_FORMATTER.format(build.getTimestamp().getTime());
+    timestamp = formatDateIso(build.getTime());
   }
 
   @Override
@@ -349,11 +350,8 @@ public class BuildData {
     return timestamp;
   }
 
-  @SuppressFBWarnings(
-    value="STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE",
-    justification="TODO: not sure how to fix this")
   public void setTimestamp(Calendar timestamp) {
-    this.timestamp = DATE_FORMATTER.format(timestamp.getTime());
+    this.timestamp = formatDateIso(timestamp.getTime());
   }
 
   public String getRootProjectName() {

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -57,6 +57,8 @@ import org.apache.commons.lang.StringUtils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * POJO for mapping build info to JSON.
  *
@@ -65,6 +67,9 @@ import com.google.gson.GsonBuilder;
  */
 public class BuildData {
   // ISO 8601 date format
+  @SuppressFBWarnings(
+    value="STCAL_STATIC_SIMPLE_DATE_FORMAT_INSTANCE",
+    justification="TODO: not sure how to fix this")
   public transient static final DateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
   private final static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getCanonicalName());
   public static class TestData {
@@ -86,6 +91,9 @@ public class BuildData {
       this(null);
     }
 
+    @SuppressFBWarnings(
+      value="URF_UNREAD_FIELD",
+      justification="TODO: not sure how to fix this")
     public TestData(Action action) {
       AbstractTestResultAction<?> testResultAction = null;
       if (action instanceof AbstractTestResultAction) {
@@ -207,6 +215,9 @@ public class BuildData {
     }
   }
 
+  @SuppressFBWarnings(
+    value={"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE","STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE"},
+    justification="TODO: not sure how to fix this")
   private void initData(Run<?, ?> build, Date currentTime) {
     result = build.getResult() == null ? null : build.getResult().toString();
     id = build.getId();
@@ -338,6 +349,9 @@ public class BuildData {
     return timestamp;
   }
 
+  @SuppressFBWarnings(
+    value="STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE",
+    justification="TODO: not sure how to fix this")
   public void setTimestamp(Calendar timestamp) {
     this.timestamp = DATE_FORMATTER.format(timestamp.getTime());
   }

--- a/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
@@ -45,6 +45,8 @@ import java.net.URISyntaxException;
 
 import com.google.common.collect.Range;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Elastic Search Data Access Object.
  *
@@ -63,6 +65,9 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
   }
 
   // Factored for unit testing
+  @SuppressFBWarnings(
+    value="DM_DEFAULT_ENCODING",
+    justification="TODO: not sure how to fix this")
   ElasticSearchDao(HttpClientBuilder factory, String host, int port, String key, String username, String password) {
     super(host, port, key, username, password);
 
@@ -127,6 +132,9 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
     }
   }
 
+  @SuppressFBWarnings(
+    value="DM_DEFAULT_ENCODING",
+    justification="TODO: not sure how to fix this")
   private String getErrorMessage(CloseableHttpResponse response) {
     ByteArrayOutputStream byteStream = null;
     PrintStream stream = null;

--- a/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/IndexerDaoFactory.java
@@ -35,6 +35,8 @@ import jenkins.plugins.logstash.persistence.LogstashIndexerDao.IndexerType;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Factory for AbstractLogstashIndexerDao objects.
  *
@@ -74,6 +76,9 @@ public final class IndexerDaoFactory {
    * @return The instance of the appropriate indexer DAO, never null
    * @throws InstantiationException
    */
+  @SuppressFBWarnings(
+    value="BX_UNBOXING_IMMEDIATELY_REBOXED",
+    justification="TODO: not sure how to fix this")
   public static synchronized LogstashIndexerDao getInstance(IndexerType type, String host, Integer port, String key, String username, String password) throws InstantiationException {
     if (!INDEXER_MAP.containsKey(type)) {
       throw new InstantiationException("[logstash-plugin]: Unknown IndexerType '" + type + "'. Did you forget to configure the plugin?");

--- a/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
@@ -32,6 +32,8 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * RabbitMQ Data Access Object.
  *
@@ -68,6 +70,9 @@ public class RabbitMqDao extends AbstractLogstashIndexerDao {
   }
 
   @Override
+  @SuppressFBWarnings(
+    value="DM_DEFAULT_ENCODING",
+    justification="TODO: not sure how to fix this")
   public void push(String data) throws IOException {
     Connection connection = null;
     Channel channel = null;

--- a/src/main/resources/jenkins/plugins/logstash/LogstashBuildWrapper/config.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashBuildWrapper/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:advanced>
+    <f:entry field="script"/>
+    <f:property field="secureGroovyScript"/>
+  </f:advanced>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashBuildWrapper/help-script.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashBuildWrapper/help-script.html
@@ -1,0 +1,37 @@
+<p>
+  With this script you can filter, modify and/or group messages that are sent to the
+  configured logstash backend. The following variables are available during execution:
+  <ul>
+    <li><strong>payload</strong> - JSONObject contaning the payload to be persisted.</li>
+    <li><strong>console</strong> - a class to output messages to build log without persisting them. It also works in a sandbox: <code>console.println("my logged message")</code>.</li>
+  </ul>
+</p>
+<p>
+  The script will be executed once per each line of build console output with
+  the variable <code>payload</code> set to the complete JSON payload to be
+  sent including message, timestamp, build url, etc.
+  The line text in particular will be present under the <code>"message"</code>
+  key as an array with a single string element.
+</p>
+<p>
+  Once script completes execution, the <code>payload</code> variable will be read out
+  of current Binding and passed down to the Logstash backend to be persisted. If
+  <code>payload</code> is set to <code>null</code> by the script, then nothing will be
+  persisted.
+</p>
+<p>
+  The script within a build will be executed always using the same Binding.
+  This means that variables can be saved between script invocations.
+</p>
+<p>
+  At the end of the build a payload == null will be submitted. You can use this to
+  output any messages that you have cached for grouping or other purposes.
+</p>
+<p>
+  Example script to filter out some console messages by pattern:
+  <pre><code>
+    if (payload &amp;&amp; payload["message"][0] =~ /my needless pattern/) {
+      payload = null
+    }
+  </code></pre>
+</p>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashBuildWrapper/help.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashBuildWrapper/help.html
@@ -1,3 +1,6 @@
 <div>
-  <p>Send individual log lines to Logstash.</p>
+  <p>
+    Send individual log lines to Logstash. You can optionally filter and modify them
+    via groovy script in from advanced configuration.
+  </p>
 </div>

--- a/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.InOrder;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @SuppressWarnings("resource")
@@ -117,5 +118,18 @@ public class LogstashOutputStreamTest {
     // Verify results
     assertEquals("Results don't match", msg, buffer.toString());
     verify(mockWriter).isConnectionBroken();
+  }
+
+  @Test
+  public void writerClosedBeforeDelegate() throws Exception {
+    ByteArrayOutputStream mockBuffer = Mockito.spy(buffer);
+    new LogstashOutputStream(mockBuffer, mockWriter).close();
+
+    InOrder inOrder = Mockito.inOrder(mockBuffer, mockWriter);
+    inOrder.verify(mockWriter).close();
+    inOrder.verify(mockBuffer).close();
+
+    // Verify results
+    assertEquals("Results don't match", "", buffer.toString());
   }
 }

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -283,6 +283,7 @@ public class LogstashWriterTest {
       "}";
 
     SecureGroovyScript script = new SecureGroovyScript(scriptString, true, null);
+    script.configuringWithNonKeyItem();
     LogstashScriptProcessor processor = new LogstashScriptProcessor(script, errorBuffer);
     LogstashWriter writer = createLogstashWriter(mockBuild, errorBuffer, "http://my-jenkins-url", mockDao, mockBuildData, processor);
     errorBuffer.reset();

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.GregorianCalendar;
+import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.core.StringContains.containsString;
@@ -104,15 +104,13 @@ public class LogstashWriterTest {
     when(mockBuild.getParent()).thenReturn(mockProject);
     when(mockBuild.getBuiltOn()).thenReturn(null);
     when(mockBuild.getNumber()).thenReturn(123456);
-    when(mockBuild.getTimestamp()).thenReturn(new GregorianCalendar());
+    when(mockBuild.getTime()).thenReturn(new Date());
     when(mockBuild.getRootBuild()).thenReturn(mockBuild);
     when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
     when(mockBuild.getSensitiveBuildVariables()).thenReturn(Collections.emptySet());
     when(mockBuild.getEnvironments()).thenReturn(null);
     when(mockBuild.getAction(AbstractTestResultAction.class)).thenReturn(mockTestResultAction);
-    when(mockBuild.getLog(0)).thenReturn(Arrays.asList());
     when(mockBuild.getLog(3)).thenReturn(Arrays.asList("line 1", "line 2", "line 3", "Log truncated..."));
-    when(mockBuild.getLog(Integer.MAX_VALUE)).thenReturn(Arrays.asList("line 1", "line 2", "line 3", "line 4"));
     when(mockBuild.getEnvironment(null)).thenReturn(new EnvVars());
 
     when(mockTestResultAction.getTotalCount()).thenReturn(0);
@@ -158,7 +156,7 @@ public class LogstashWriterTest {
     // Verify that the BuildData constructor is what is being called here.
     // This also lets us verify that in the instantiation failure cases we do not construct BuildData.
     verify(mockBuild).getId();
-    verify(mockBuild, times(2)).getResult();
+    verify(mockBuild, times(1)).getResult();
     verify(mockBuild, times(2)).getParent();
     verify(mockBuild, times(2)).getProject();
     verify(mockBuild, times(1)).getStartTimeInMillis();
@@ -169,7 +167,7 @@ public class LogstashWriterTest {
     verify(mockBuild).getAction(AbstractTestResultAction.class);
     verify(mockBuild).getBuiltOn();
     verify(mockBuild, times(2)).getNumber();
-    verify(mockBuild).getTimestamp();
+    verify(mockBuild).getTime();
     verify(mockBuild, times(4)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getSensitiveBuildVariables();

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -69,10 +68,9 @@ public class BuildDataTest {
     when(mockBuild.getDisplayName()).thenReturn("BuildData Test");
     when(mockBuild.getFullDisplayName()).thenReturn("BuildData Test #123456");
     when(mockBuild.getDescription()).thenReturn("Mock project for testing BuildData");
-    when(mockBuild.getProject()).thenReturn(mockProject);
     when(mockBuild.getParent()).thenReturn(mockProject);
     when(mockBuild.getNumber()).thenReturn(123456);
-    when(mockBuild.getTimestamp()).thenReturn(new GregorianCalendar());
+    when(mockBuild.getTime()).thenReturn(new Date());
     when(mockBuild.getRootBuild()).thenReturn(mockBuild);
     when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
     when(mockBuild.getSensitiveBuildVariables()).thenReturn(Collections.emptySet());
@@ -116,7 +114,7 @@ public class BuildDataTest {
     verify(mockProject).getFullName();
 
     verify(mockBuild).getId();
-    verify(mockBuild, times(2)).getResult();
+    verify(mockBuild, times(1)).getResult();
     verify(mockBuild, times(2)).getParent();
     verify(mockBuild).getDisplayName();
     verify(mockBuild).getFullDisplayName();
@@ -126,7 +124,7 @@ public class BuildDataTest {
     verify(mockBuild).getAction(AbstractTestResultAction.class);
     verify(mockBuild).getBuiltOn();
     verify(mockBuild).getNumber();
-    verify(mockBuild).getTimestamp();
+    verify(mockBuild).getTime();
     verify(mockBuild, times(4)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getSensitiveBuildVariables();


### PR DESCRIPTION
This change requires jenkinsci/script-security-plugin#169 to work.

Please see `help-script.html` for possible use cases.

I needed to update parent pom version because of script-security-plugin which led to
the need to suppress additional warnings. Still waiting on
jenkinsci/script-security-plugin#169 to be accepted so not ready to merge. I have an
alternative approach if the pull is not accepted, unfortunately not that performant.

But I will appreciate feedback for this PR in the meanwhile so I can fix issues.

Thank you.