### PR TITLE
findbugs: fix issues in BuildData

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -64,7 +64,7 @@ import com.google.gson.GsonBuilder;
  */
 public class BuildData {
   // ISO 8601 date format
-  public transient static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+  public transient static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ");
   private final static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getCanonicalName());
   public static class TestData {
     int totalCount, skipCount, failCount, passCount;

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -26,17 +26,15 @@ package jenkins.plugins.logstash.persistence;
 
 import hudson.model.Action;
 import hudson.model.Environment;
+import hudson.model.Executor;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import hudson.model.Run;
 import hudson.model.Node;
-import hudson.model.Executor;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -53,6 +51,7 @@ import java.lang.invoke.MethodHandles;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.time.FastDateFormat;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -65,7 +64,7 @@ import com.google.gson.GsonBuilder;
  */
 public class BuildData {
   // ISO 8601 date format
-  public transient static final DateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+  public transient static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
   private final static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getCanonicalName());
   public static class TestData {
     int totalCount, skipCount, failCount, passCount;
@@ -138,15 +137,6 @@ public class BuildData {
   public BuildData(AbstractBuild<?, ?> build, Date currentTime, TaskListener listener) {
     initData(build, currentTime);
 
-    Node node = build.getExecutor().getOwner().getNode();
-    if (node == null) {
-      buildHost = "master";
-      buildLabel = "master";
-    } else {
-      buildHost = StringUtils.isBlank(node.getDisplayName()) ? "master" : node.getDisplayName();
-      buildLabel = StringUtils.isBlank(node.getLabelString()) ? "master" : node.getLabelString();
-    }
-
     // build.getDuration() is always 0 in Notifiers
     rootProjectName = build.getRootBuild().getProject().getName();
     rootFullProjectName = build.getRootBuild().getProject().getFullName();
@@ -186,15 +176,6 @@ public class BuildData {
   public BuildData(Run<?, ?> build, Date currentTime, TaskListener listener) {
     initData(build, currentTime);
 
-    Node node = build.getExecutor().getOwner().getNode();
-    if (node == null) {
-      buildHost = "master";
-      buildLabel = "master";
-    } else {
-      buildHost = StringUtils.isBlank(node.getDisplayName()) ? "master" : node.getDisplayName();
-      buildLabel = StringUtils.isBlank(node.getLabelString()) ? "master" : node.getLabelString();
-    }
-
     rootProjectName = projectName;
     rootFullProjectName = fullProjectName;
     rootProjectDisplayName = displayName;
@@ -210,7 +191,24 @@ public class BuildData {
   }
 
   private void initData(Run<?, ?> build, Date currentTime) {
-    result = build.getResult() == null ? null : build.getResult().toString();
+
+    Executor executor = build.getExecutor();
+    if (executor == null) {
+        buildHost = "master";
+        buildLabel = "master";
+    } else {
+        Node node = executor.getOwner().getNode();
+        if (node == null) {
+          buildHost = "master";
+          buildLabel = "master";
+        } else {
+          buildHost = StringUtils.isBlank(node.getDisplayName()) ? "master" : node.getDisplayName();
+          buildLabel = StringUtils.isBlank(node.getLabelString()) ? "master" : node.getLabelString();
+        }
+    }
+
+    Result result = build.getResult();
+    this.result = result == null ? null : result.toString();
     id = build.getId();
     projectName = build.getParent().getName();
     fullProjectName = build.getParent().getFullName();

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -139,7 +139,7 @@ public class LogstashWriterTest {
     // Verify that the BuildData constructor is what is being called here.
     // This also lets us verify that in the instantiation failure cases we do not construct BuildData.
     verify(mockBuild).getId();
-    verify(mockBuild, times(2)).getResult();
+    verify(mockBuild).getResult();
     verify(mockBuild, times(2)).getParent();
     verify(mockBuild, times(2)).getProject();
     verify(mockBuild, times(1)).getStartTimeInMillis();

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -121,7 +121,7 @@ public class BuildDataTest {
     verify(mockProject).getFullName();
 
     verify(mockBuild).getId();
-    verify(mockBuild, times(2)).getResult();
+    verify(mockBuild).getResult();
     verify(mockBuild, times(2)).getParent();
     verify(mockBuild).getDisplayName();
     verify(mockBuild).getFullDisplayName();


### PR DESCRIPTION
Use FastDateFormat from apache which is thread safe

Avoid possible NPE in Node detection
Avoid possible NPE in result (previous logic already avoided it but findbugs still claimed it to be a problem)

Node detection is same for pipeline and freestyle so move it to initData method
