### PR TITLE
findbugs: fix default encoding issues

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
@@ -46,7 +46,6 @@ import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsConfig;
 
 /**
  * Build wrapper that decorates the build's logger to insert a
- * {@link LogstashNote} on each output line.
  *
  * @author K Jonathan Harker
  */
@@ -102,13 +101,14 @@ public class LogstashBuildWrapper extends BuildWrapper {
     return los;
   }
 
+  @Override
   public DescriptorImpl getDescriptor() {
     return (DescriptorImpl) super.getDescriptor();
   }
 
   // Method to encapsulate calls for unit-testing
   LogstashWriter getLogStashWriter(AbstractBuild<?, ?> build, OutputStream errorStream) {
-    return new LogstashWriter(build, errorStream, null);
+    return new LogstashWriter(build, errorStream, null, build.getCharset());
   }
 
   /**

--- a/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
@@ -85,9 +85,10 @@ public class LogstashNotifier extends Notifier implements SimpleBuildStep {
 
   // Method to encapsulate calls for unit-testing
   LogstashWriter getLogStashWriter(Run<?, ?> run, OutputStream errorStream, TaskListener listener) {
-    return new LogstashWriter(run, errorStream, listener);
+    return new LogstashWriter(run, errorStream, listener, run.getCharset());
   }
 
+  @Override
   public BuildStepMonitor getRequiredMonitorService() {
     // We don't call Run#getPreviousBuild() so no external synchronization between builds is required
     return BuildStepMonitor.NONE;
@@ -106,6 +107,7 @@ public class LogstashNotifier extends Notifier implements SimpleBuildStep {
       return true;
     }
 
+    @Override
     public String getDisplayName() {
       return Messages.DisplayName();
     }

--- a/src/main/java/jenkins/plugins/logstash/LogstashOutputStream.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashOutputStream.java
@@ -66,7 +66,7 @@ public class LogstashOutputStream extends LineTransformationOutputStream {
     this.flush();
 
     if(!logstash.isConnectionBroken()) {
-      String line = new String(b, 0, len).trim();
+      String line = new String(b, 0, len, logstash.getCharset()).trim();
       line = ConsoleNote.removeNotes(line);
       logstash.write(line);
     }

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -58,12 +58,22 @@ public abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
     }
   }
 
+  /**
+   * Sets the charset used to push data to the indexer
+   *
+   *@param charset The charset to push data
+   */
   @Override
   public void setCharset(Charset charset)
   {
     this.charset = charset;
   }
 
+  /**
+   * Gets the configured charset used to push data to the indexer
+   *
+   * @return charste to push data
+   */
   public Charset getCharset()
   {
     return charset;

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.logstash.persistence;
 
+import java.nio.charset.Charset;
 import java.util.Calendar;
 import java.util.List;
 
@@ -43,6 +44,7 @@ public abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
   protected final String key;
   protected final String username;
   protected final String password;
+  private Charset charset;
 
   public AbstractLogstashIndexerDao(String host, int port, String key, String username, String password) {
     this.host = host;
@@ -54,6 +56,17 @@ public abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
     if (StringUtils.isBlank(host)) {
       throw new IllegalArgumentException("host name is required");
     }
+  }
+
+  @Override
+  public void setCharset(Charset charset)
+  {
+    this.charset = charset;
+  }
+
+  public Charset getCharset()
+  {
+    return charset;
   }
 
   @Override

--- a/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
@@ -40,8 +40,11 @@ import org.apache.http.client.utils.URIBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import com.google.common.collect.Range;
 
@@ -85,7 +88,7 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
     }
 
     if (StringUtils.isNotBlank(username)) {
-      auth = Base64.encodeBase64String((username + ":" + StringUtils.defaultString(password)).getBytes());
+      auth = Base64.encodeBase64String((username + ":" + StringUtils.defaultString(password)).getBytes(StandardCharsets.UTF_8));
     } else {
       auth = null;
     }
@@ -132,7 +135,7 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
     PrintStream stream = null;
     try {
       byteStream = new ByteArrayOutputStream();
-      stream = new PrintStream(byteStream);
+      stream = new PrintStream(byteStream, true, StandardCharsets.UTF_8.name());
 
       try {
         stream.print("HTTP error code: ");
@@ -145,7 +148,11 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
         stream.println(ExceptionUtils.getStackTrace(e));
       }
       stream.flush();
-      return byteStream.toString();
+      return byteStream.toString(StandardCharsets.UTF_8.name());
+    }
+    catch (UnsupportedEncodingException e)
+    {
+      return ExceptionUtils.getStackTrace(e);
     } finally {
       if (stream != null) {
         stream.close();

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
@@ -25,6 +25,7 @@
 package jenkins.plugins.logstash.persistence;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 
 import net.sf.json.JSONObject;
@@ -42,7 +43,7 @@ public interface LogstashIndexerDao {
     ELASTICSEARCH,
     SYSLOG
   }
-  
+
   static enum SyslogFormat {
 	RFC5424,
 	RFC3164
@@ -51,7 +52,9 @@ public interface LogstashIndexerDao {
   static enum SyslogProtocol {
 	UDP
   }
-  
+
+  public void setCharset(Charset charset);
+
   String getDescription();
 
   IndexerType getIndexerType();

--- a/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
@@ -87,7 +87,7 @@ public class RabbitMqDao extends AbstractLogstashIndexerDao {
         channel.queueDeclare(key, true, false, false, null);
       }
 
-      channel.basicPublish("", key, null, data.getBytes());
+      channel.basicPublish("", key, null, data.getBytes(getCharset()));
     } finally {
       finalizeChannel(channel);
       finalizeConnection(connection);

--- a/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 import org.junit.After;
 import org.junit.Before;
@@ -32,6 +33,7 @@ public class LogstashOutputStreamTest {
     buffer = new ByteArrayOutputStream();
     Mockito.doNothing().when(mockWriter).write(anyString());
     when(mockWriter.isConnectionBroken()).thenReturn(false);
+    when(mockWriter.getCharset()).thenReturn(Charset.defaultCharset());
   }
 
   @After
@@ -61,6 +63,7 @@ public class LogstashOutputStreamTest {
     assertEquals("Results don't match", msg, buffer.toString());
     verify(mockWriter).isConnectionBroken();
     verify(mockWriter).write(msg);
+    verify(mockWriter).getCharset();
   }
 
   @Test
@@ -102,6 +105,7 @@ public class LogstashOutputStreamTest {
     //Verify calls were made to the dao logging twice, not three times.
     verify(mockWriter, times(2)).write(msg);
     verify(mockWriter, times(3)).isConnectionBroken();
+    verify(mockWriter, times(2)).getCharset();
   }
 
   @Test

--- a/src/test/java/jenkins/plugins/logstash/persistence/RabbitMqDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/RabbitMqDaoTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.net.SocketException;
+import java.nio.charset.Charset;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -36,6 +37,8 @@ public class RabbitMqDaoTest {
       verify(mockPool, atLeastOnce()).setUsername(username);
       verify(mockPool, atLeastOnce()).setPassword(password);
     }
+
+    factory.setCharset(Charset.defaultCharset());
 
     return factory;
   }


### PR DESCRIPTION
Get the charset of a run and use it whenever we need to convert the String to a byte array.
