### PR TITLE
Add support for Elasticsearch pipelines

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashInstallation.java
@@ -76,6 +76,7 @@ public class LogstashInstallation extends ToolInstallation {
     private String username;
     private String password;
     private String key;
+    private String pipeline;
 
     public Descriptor() {
       super();
@@ -210,5 +211,14 @@ public class LogstashInstallation extends ToolInstallation {
       this.key = key;
     }
 
+    public String getPipeline()
+    {
+      return pipeline;
+    }
+
+    public void setPipeline(String pipeline)
+    {
+      this.pipeline = pipeline;
+    }
   }
 }

--- a/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/global.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/global.jelly
@@ -22,6 +22,9 @@
         checkUrl="'${resURL}/descriptorByName/LogstashInstallation/checkString?value='+escape(this.value)" />
     </f:entry>
     <f:advanced>
+      <f:entry title="${%Elasticsearch pipeline}" field="pipeline">
+        <f:textbox value="${descriptor.pipeline}" />
+      </f:entry>
       <f:entry title="${%Syslog format}" field="syslogFormat">
         <f:enum value="${descriptor.syslogFormat}">${it.name()}</f:enum>
       </f:entry>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-pipeline.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashInstallation/help-pipeline.html
@@ -1,0 +1,4 @@
+<div>
+    <p>The elasticsearch pipeline to send logs through (only effective for ELASTICSEARCH Indexer type).<br/>
+        Leave this field blank if you are not routing through a pipeline.</p>
+</div>


### PR DESCRIPTION
This adds support for Elasticsearch pipelines to allow for transformation of documents. We are currently running this in production without any issues pushing to Elasticsearch 6.0.