### PR TITLE
[JENKINS-33635] option to enable logstash globally

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
@@ -1,6 +1,5 @@
 package jenkins.plugins.logstash;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -35,12 +34,23 @@ public class LogstashConfiguration extends GlobalConfiguration
   private static final Logger LOGGER = Logger.getLogger(LogstashConfiguration.class.getName());
   private LogstashIndexer<?> logstashIndexer;
   private boolean dataMigrated = false;
+  private boolean enableGlobally = false;
   private transient LogstashIndexer<?> activeIndexer;
 
   public LogstashConfiguration()
   {
     load();
     activeIndexer = logstashIndexer;
+  }
+
+  public boolean isEnableGlobally()
+  {
+    return enableGlobally;
+  }
+
+  public void setEnableGlobally(boolean enableGlobally)
+  {
+    this.enableGlobally = enableGlobally;
   }
 
   /**

--- a/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
@@ -57,6 +57,12 @@ public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serial
 
   private boolean isLogstashEnabled(Run<?, ?> build)
   {
+    LogstashConfiguration configuration = LogstashConfiguration.getInstance();
+    if (configuration.isEnableGlobally())
+    {
+      return true;
+    }
+
     if (build.getParent() instanceof BuildableItemWithBuildWrappers)
     {
       BuildableItemWithBuildWrappers project = (BuildableItemWithBuildWrappers)build.getParent();

--- a/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/config.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/config.jelly
@@ -4,5 +4,8 @@
     <f:entry>
     	<f:dropdownDescriptorSelector title="${%Indexer Type}" field="logstashIndexer" descriptors="${descriptor.indexerTypes}"/>
     </f:entry>
+    <f:entry title="Enable Globally" field="enableGlobally">
+      <f:checkbox/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/config.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/config.jelly
@@ -4,7 +4,7 @@
     <f:entry>
     	<f:dropdownDescriptorSelector title="${%Indexer Type}" field="logstashIndexer" descriptors="${descriptor.indexerTypes}"/>
     </f:entry>
-    <f:entry title="Enable Globally" field="enableGlobally">
+    <f:entry title="Enable Globally" field="enableGlobally" description="This will not enable it for pipeline jobs.">
       <f:checkbox/>
     </f:entry>
   </f:section>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/help-enableGlobally.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/help-enableGlobally.html
@@ -1,0 +1,1 @@
+Checking will make all non pipeline builds forward their log to the above indexer.

--- a/src/test/java/jenkins/plugins/logstash/LogstashConsoloLogFilterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashConsoloLogFilterTest.java
@@ -107,7 +107,7 @@ public class LogstashConsoloLogFilterTest {
   }
 
   @Test
-  public void decorateLoggerSuccessNoLogstashBuildWrapper() throws Exception {
+  public void decorateLoggerSuccessLogstashNotEnabled() throws Exception {
     MockLogstashConsoloeLogFilter buildWrapper = new MockLogstashConsoloeLogFilter(mockWriter);
 
     // Unit under test

--- a/src/test/java/jenkins/plugins/logstash/LogstashConsoloLogFilterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashConsoloLogFilterTest.java
@@ -2,7 +2,7 @@ package jenkins.plugins.logstash;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.when;
 import static org.mockito.Mockito.verify;
 
 import hudson.model.AbstractBuild;
@@ -24,9 +24,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
+@PrepareForTest(LogstashConfiguration.class)
 public class LogstashConsoloLogFilterTest {
+
+  @Mock
+  private LogstashConfiguration logstashConfiguration;
+
   // Extension of the unit under test that avoids making calls to statics or constructors
   static class MockLogstashConsoloeLogFilter extends LogstashConsoleLogFilter {
     LogstashWriter writer;
@@ -62,6 +72,10 @@ public class LogstashConsoloLogFilterTest {
   @Before
   public void before() throws Exception {
     buildWrappers = new DescribableList<BuildWrapper,Descriptor<BuildWrapper>>(mockProject);
+    PowerMockito.mockStatic(LogstashConfiguration.class);
+    when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
+    when(logstashConfiguration.isEnableGlobally()).thenReturn(false);
+
     when(mockWriter.isConnectionBroken()).thenReturn(false);
     when(mockBuild.getParent()).thenReturn(mockProject);
     when(mockProject.getBuildWrappersList()).thenReturn(buildWrappers);
@@ -77,7 +91,7 @@ public class LogstashConsoloLogFilterTest {
   }
 
   @Test
-  public void decorateLoggerSuccess() throws Exception {
+  public void decorateLoggerSuccessBuildWrapper() throws Exception {
     buildWrappers.add(new LogstashBuildWrapper());
     MockLogstashConsoloeLogFilter buildWrapper = new MockLogstashConsoloeLogFilter(mockWriter);
 
@@ -120,6 +134,23 @@ public class LogstashConsoloLogFilterTest {
     assertTrue("Result is not the right type", result instanceof LogstashOutputStream);
     assertSame("Result has wrong writer", mockWriter, ((LogstashOutputStream) result).getLogstashWriter());
     assertEquals("Error was not written", "Mocked Constructor failure", buffer.toString());
+    verify(mockWriter).isConnectionBroken();
+  }
+
+  @Test
+  public void decorateLoggerSuccessEnabledGlobally() throws IOException, InterruptedException
+  {
+    when(logstashConfiguration.isEnableGlobally()).thenReturn(true);
+    MockLogstashConsoloeLogFilter buildWrapper = new MockLogstashConsoloeLogFilter(mockWriter);
+
+    // Unit under test
+    OutputStream result = buildWrapper.decorateLogger(mockBuild, buffer);
+
+    // Verify results
+    assertNotNull("Result was null", result);
+    assertTrue("Result is not the right type", result instanceof LogstashOutputStream);
+    assertSame("Result has wrong writer", mockWriter, ((LogstashOutputStream) result).getLogstashWriter());
+    assertEquals("Results don't match", "", buffer.toString());
     verify(mockWriter).isConnectionBroken();
   }
 }

--- a/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
@@ -212,4 +212,23 @@ public class LogstashIntegrationTest
         assertThat(logline,not(containsString("myPassword")));
       }
     }
+
+    @Test
+    public void enableGlobally() throws Exception
+    {
+      when(logstashConfiguration.isEnableGlobally()).thenReturn(true);
+      QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
+
+      FreeStyleBuild build = f.get();
+      assertThat(build.getResult(), equalTo(Result.SUCCESS));
+      List<JSONObject> dataLines = memoryDao.getOutput();
+      assertThat(dataLines.size(), is(4));
+      JSONObject firstLine = dataLines.get(0);
+      JSONObject lastLine = dataLines.get(dataLines.size()-1);
+      JSONObject data = firstLine.getJSONObject("data");
+      assertThat(data.getString("buildHost"),equalTo("Jenkins"));
+      assertThat(data.getString("buildLabel"),equalTo("master"));
+      assertThat(lastLine.getJSONArray("message").get(0).toString(),equalTo("Finished: SUCCESS"));
+    }
+
 }


### PR DESCRIPTION
With the ConsoleLogFilter we can enable it globally to send the log to
the indexer. Unfortunately this will not work for pipeline builds.