### PR TITLE
[JENKINS-49960] use a Jobproperty instead of a BuildWrapper

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
@@ -38,10 +38,9 @@ import hudson.tasks.BuildWrapperDescriptor;
 
 /**
  *
- * This BuildWrapper is only a marker and has no other functionality.
- * The {@link LogstashConsoleLogFilter} uses this BuildWrapper to decide if it should send the log to an indexer.
- * We have to keep this for backward compatibility as in the past this BuildWrapper was used instead.
- * Using a ConsoleLogFilter allows to remove the dependency to the maskpasswords plugin.
+ * This BuildWrapper is not used anymore.
+ * We just keep it to be able to convert projects that have the BuildWrapper configured at startup or when posting the xml via the rest api
+ * to the JobProperty.
  *
  * @author K Jonathan Harker
  */

--- a/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashBuildWrapper.java
@@ -45,6 +45,7 @@ import hudson.tasks.BuildWrapperDescriptor;
  *
  * @author K Jonathan Harker
  */
+@Deprecated
 public class LogstashBuildWrapper extends BuildWrapper
 {
 
@@ -76,8 +77,7 @@ public class LogstashBuildWrapper extends BuildWrapper
   /**
    * Registers {@link LogstashBuildWrapper} as a {@link BuildWrapper}.
    */
-  // We need a high ordinal so that we are in the list of BuildWrappers before the MaskPasswords
-  @Extension(ordinal = 10000)
+  @Extension
   public static class DescriptorImpl extends BuildWrapperDescriptor
   {
 
@@ -102,7 +102,7 @@ public class LogstashBuildWrapper extends BuildWrapper
     @Override
     public boolean isApplicable(AbstractProject<?, ?> item)
     {
-      return true;
+      return false;
     }
   }
 }

--- a/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
@@ -8,9 +8,7 @@ import hudson.Extension;
 import hudson.console.ConsoleLogFilter;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.Run;
-import hudson.tasks.BuildWrapper;
 
 @Extension(ordinal = 1000)
 public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serializable

--- a/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import hudson.Extension;
 import hudson.console.ConsoleLogFilter;
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
 import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.Run;
 import hudson.tasks.BuildWrapper;
@@ -63,15 +64,12 @@ public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serial
       return true;
     }
 
-    if (build.getParent() instanceof BuildableItemWithBuildWrappers)
+    if (build.getParent() instanceof AbstractProject)
     {
-      BuildableItemWithBuildWrappers project = (BuildableItemWithBuildWrappers)build.getParent();
-      for (BuildWrapper wrapper : project.getBuildWrappersList())
+      AbstractProject<?, ?> project = (AbstractProject<?, ?>)build.getParent();
+      if (project.getProperty(LogstashJobProperty.class) != null)
       {
-        if (wrapper instanceof LogstashBuildWrapper)
-        {
-          return true;
-        }
+        return true;
       }
     }
     return false;

--- a/src/main/java/jenkins/plugins/logstash/LogstashItemListener.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashItemListener.java
@@ -24,6 +24,15 @@ public class LogstashItemListener extends ItemListener
   private static Logger LOGGER = Logger.getLogger(LogstashItemListener.class.getName());
 
   @Override
+  public void onCreated(Item item)
+  {
+    if (item instanceof BuildableItemWithBuildWrappers)
+    {
+      convertBuildWrapperToJobProperty((BuildableItemWithBuildWrappers)item);
+    }
+  }
+
+  @Override
   public void onLoaded()
   {
     for (BuildableItemWithBuildWrappers item : Jenkins.getInstance().getAllItems(BuildableItemWithBuildWrappers.class))

--- a/src/main/java/jenkins/plugins/logstash/LogstashItemListener.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashItemListener.java
@@ -24,15 +24,6 @@ public class LogstashItemListener extends ItemListener
   private static Logger LOGGER = Logger.getLogger(LogstashItemListener.class.getName());
 
   @Override
-  public void onCreated(Item item)
-  {
-    if (item instanceof BuildableItemWithBuildWrappers)
-    {
-      convertBuildWrapperToJobProperty((BuildableItemWithBuildWrappers)item);
-    }
-  }
-
-  @Override
   public void onLoaded()
   {
     for (BuildableItemWithBuildWrappers item : Jenkins.getInstance().getAllItems(BuildableItemWithBuildWrappers.class))
@@ -41,7 +32,7 @@ public class LogstashItemListener extends ItemListener
     }
   }
 
-  private void convertBuildWrapperToJobProperty(BuildableItemWithBuildWrappers item)
+  static void convertBuildWrapperToJobProperty(BuildableItemWithBuildWrappers item)
   {
     DescribableList<BuildWrapper, Descriptor<BuildWrapper>> wrappers = item.getBuildWrappersList();
     LogstashBuildWrapper logstashBuildWrapper = wrappers.get(LogstashBuildWrapper.class);

--- a/src/main/java/jenkins/plugins/logstash/LogstashItemListener.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashItemListener.java
@@ -1,0 +1,70 @@
+package jenkins.plugins.logstash;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import hudson.BulkChange;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.BuildableItemWithBuildWrappers;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.listeners.ItemListener;
+import hudson.tasks.BuildWrapper;
+import hudson.util.DescribableList;
+import jenkins.model.Jenkins;
+
+@Extension
+public class LogstashItemListener extends ItemListener
+{
+
+  private static Logger LOGGER = Logger.getLogger(LogstashItemListener.class.getName());
+
+  @Override
+  public void onCreated(Item item)
+  {
+    if (item instanceof BuildableItemWithBuildWrappers)
+    {
+      convertBuildWrapperToJobProperty((BuildableItemWithBuildWrappers)item);
+    }
+  }
+
+  @Override
+  public void onLoaded()
+  {
+    for (BuildableItemWithBuildWrappers item : Jenkins.getInstance().getAllItems(BuildableItemWithBuildWrappers.class))
+    {
+      convertBuildWrapperToJobProperty(item);
+    }
+  }
+
+  private void convertBuildWrapperToJobProperty(BuildableItemWithBuildWrappers item)
+  {
+    DescribableList<BuildWrapper, Descriptor<BuildWrapper>> wrappers = item.getBuildWrappersList();
+    LogstashBuildWrapper logstashBuildWrapper = wrappers.get(LogstashBuildWrapper.class);
+    if (logstashBuildWrapper != null && item instanceof AbstractProject<?, ?>)
+    {
+      AbstractProject<?, ?> project = (AbstractProject<?, ?>)item;
+      BulkChange bc = new BulkChange(project);
+      try
+      {
+        project.addProperty(new LogstashJobProperty());
+        wrappers.remove(logstashBuildWrapper);
+        bc.commit();
+      }
+      catch (IOException e)
+      {
+        LOGGER.log(Level.SEVERE,
+            "Failed to convert LogstashBuildWrapper to LogstashJobProperty for project " + project.getFullName(), e);
+      }
+      finally
+      {
+        bc.abort();
+      }
+    }
+  }
+
+}

--- a/src/main/java/jenkins/plugins/logstash/LogstashJobProperty.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashJobProperty.java
@@ -1,0 +1,45 @@
+package jenkins.plugins.logstash;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import net.sf.json.JSONObject;
+
+public class LogstashJobProperty extends JobProperty<Job<?, ?>>
+{
+
+  @DataBoundConstructor
+  public LogstashJobProperty()
+  {}
+
+  @Extension
+  public static class DescriptorImpl extends JobPropertyDescriptor
+  {
+    @Override
+    public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException
+    {
+      if (formData.containsKey("enable"))
+      {
+        return new LogstashJobProperty();
+      }
+      return null;
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+      return Messages.DisplayName();
+    }
+
+    @Override
+    public boolean isApplicable(Class<? extends Job> jobType)
+    {
+      return AbstractProject.class.isAssignableFrom(jobType);
+    }
+  }
+}

--- a/src/main/java/jenkins/plugins/logstash/LogstashJobProperty.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashJobProperty.java
@@ -10,6 +10,10 @@ import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import net.sf.json.JSONObject;
 
+/**
+ * This JobProperty is a marker to decide if logs should be sent to an indexer.
+ *
+ */
 public class LogstashJobProperty extends JobProperty<Job<?, ?>>
 {
 

--- a/src/main/java/jenkins/plugins/logstash/LogstashSaveableListener.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashSaveableListener.java
@@ -1,0 +1,22 @@
+package jenkins.plugins.logstash;
+
+import hudson.Extension;
+import hudson.XmlFile;
+import hudson.model.BuildableItemWithBuildWrappers;
+import hudson.model.Saveable;
+import hudson.model.listeners.SaveableListener;
+
+@Extension
+public class LogstashSaveableListener extends SaveableListener
+{
+
+  @Override
+  public void onChange(Saveable o, XmlFile file)
+  {
+    if (o instanceof BuildableItemWithBuildWrappers)
+    {
+      LogstashItemListener.convertBuildWrapperToJobProperty((BuildableItemWithBuildWrappers)o);
+    }
+  }
+
+}

--- a/src/main/resources/jenkins/plugins/logstash/LogstashBuildWrapper/help.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashBuildWrapper/help.html
@@ -1,3 +1,0 @@
-<div>
-  <p>Send individual log lines to Logstash.</p>
-</div>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashJobProperty/config.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:optionalBlock name="enable" title="${descriptor.displayName}" checked="${instance != null}" help="/plugin/logstash/help/help.html">
+	</f:optionalBlock>
+</j:jelly>

--- a/src/main/webapp/help/help.html
+++ b/src/main/webapp/help/help.html
@@ -1,0 +1,1 @@
+Send individual log lines to Logstash.

--- a/src/test/java/jenkins/plugins/logstash/LogstashBuildWrapperConversionTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashBuildWrapperConversionTest.java
@@ -64,6 +64,7 @@ public class LogstashBuildWrapperConversionTest
     try
     {
       request.setRequestBody("<?xml version='1.0' encoding='UTF-8'?>\n<project>\n" +
+          "<properties/>" +
           "<buildWrappers>" +
           "<jenkins.plugins.logstash.LogstashBuildWrapper/>" +
           "</buildWrappers>" +

--- a/src/test/java/jenkins/plugins/logstash/LogstashBuildWrapperConversionTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashBuildWrapperConversionTest.java
@@ -1,0 +1,46 @@
+package jenkins.plugins.logstash;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockFolder;
+
+import hudson.model.Project;
+
+public class LogstashBuildWrapperConversionTest
+{
+  @Rule
+  public JenkinsRule j;
+
+  public LogstashBuildWrapperConversionTest() throws Exception
+  {
+    j = new JenkinsRule().withExistingHome(new File("src/test/resources/home"));
+  }
+
+  @Test
+  public void existingJobIsConvertedAtStartup()
+  {
+    Project<?, ?> item = (Project<?, ?>) j.getInstance().getItem("test");
+
+    assertThat(item.getBuildWrappersList().get(LogstashBuildWrapper.class), equalTo(null));
+    assertThat(item.getProperty(LogstashJobProperty.class), not(equalTo(null)));
+  }
+
+  @Test
+  public void buildWrapperIsConvertedToJobPropertyWhenPostingXML() throws IOException
+  {
+    MockFolder folder = j.createFolder("folder");
+    FileInputStream xml = new FileInputStream("src/test/resources/buildWrapperConfig.xml");
+    Project<?, ?> item = (Project<?, ?>) folder.createProjectFromXML("converted", xml);
+    assertThat(item.getBuildWrappersList().get(LogstashBuildWrapper.class), equalTo(null));
+    assertThat(item.getProperty(LogstashJobProperty.class), not(equalTo(null)));
+  }
+}

--- a/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
@@ -69,7 +69,7 @@ public class LogstashIntegrationTest
     @Test
     public void buildWrapperOnMaster() throws Exception
     {
-        project.getBuildWrappersList().add(new LogstashBuildWrapper());
+        project.addProperty(new LogstashJobProperty());
         QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
         FreeStyleBuild build = f.get();
         assertThat(build.getResult(), equalTo(Result.SUCCESS));
@@ -86,7 +86,7 @@ public class LogstashIntegrationTest
     @Test
     public void buildWrapperOnSlave() throws Exception
     {
-        project.getBuildWrappersList().add(new LogstashBuildWrapper());
+        project.addProperty(new LogstashJobProperty());
         project.setAssignedNode(slave);
 
         QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
@@ -134,7 +134,7 @@ public class LogstashIntegrationTest
     }
 
     @Test
-    public void passwordsAreMaskedWithWrongOrderOfBuildWrappers() throws Exception
+    public void passwordsAreMaskedWithMaskpasswordsBuildWrapper() throws Exception
     {
       EnvInjectJobPropertyInfo info = new EnvInjectJobPropertyInfo(null, "PWD=myPassword", null, null, false, null);
       EnvInjectBuildWrapper e = new EnvInjectBuildWrapper(info);
@@ -144,35 +144,7 @@ public class LogstashIntegrationTest
       pwdPairs.add(pwdPair);
       MaskPasswordsBuildWrapper maskPwdWrapper = new MaskPasswordsBuildWrapper(pwdPairs);
 
-      // Here the wrapper are in the wrong order, but it should still work
-      project.getBuildWrappersList().add(maskPwdWrapper);
-      project.getBuildWrappersList().add(e);
-      project.getBuildWrappersList().add(new LogstashBuildWrapper());
-      QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
-
-      FreeStyleBuild build = f.get();
-      assertThat(build.getResult(), equalTo(Result.SUCCESS));
-      List<JSONObject> dataLines = memoryDao.getOutput();
-      for (JSONObject line: dataLines)
-      {
-        JSONArray message = line.getJSONArray("message");
-        String logline = (String) message.get(0);
-        assertThat(logline,not(containsString("myPassword")));
-      }
-    }
-
-    @Test
-    public void passwordsAreMaskedWithCorrectOrderOfBuildWrappers() throws Exception
-    {
-      EnvInjectJobPropertyInfo info = new EnvInjectJobPropertyInfo(null, "PWD=myPassword", null, null, false, null);
-      EnvInjectBuildWrapper e = new EnvInjectBuildWrapper(info);
-
-      List<VarPasswordPair> pwdPairs = new ArrayList<>();
-      VarPasswordPair pwdPair = new VarPasswordPair("PWD", "myPassword");
-      pwdPairs.add(pwdPair);
-      MaskPasswordsBuildWrapper maskPwdWrapper = new MaskPasswordsBuildWrapper(pwdPairs);
-
-      project.getBuildWrappersList().add(new LogstashBuildWrapper());
+      project.addProperty(new LogstashJobProperty());
       project.getBuildWrappersList().add(maskPwdWrapper);
       project.getBuildWrappersList().add(e);
       QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
@@ -189,7 +161,7 @@ public class LogstashIntegrationTest
     }
 
     @Test
-    public void passwordsAreMaskedWithoutMaskPasswordsBuildWrapper() throws Exception
+    public void passwordsAreMaskedWithGlobalMaskPasswordsConfiguration() throws Exception
     {
       MaskPasswordsConfig config = MaskPasswordsConfig.getInstance();
       config.setGlobalVarEnabledGlobally(true);
@@ -199,7 +171,7 @@ public class LogstashIntegrationTest
       EnvInjectBuildWrapper e = new EnvInjectBuildWrapper(info);
 
       project.getBuildWrappersList().add(e);
-      project.getBuildWrappersList().add(new LogstashBuildWrapper());
+      project.addProperty(new LogstashJobProperty());
       QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
 
       FreeStyleBuild build = f.get();

--- a/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
@@ -67,7 +67,7 @@ public class LogstashIntegrationTest
     }
 
     @Test
-    public void buildWrapperOnMaster() throws Exception
+    public void dataIsSetWhenEnabledViaJobPropertyOnMaster() throws Exception
     {
         project.addProperty(new LogstashJobProperty());
         QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
@@ -84,7 +84,7 @@ public class LogstashIntegrationTest
     }
 
     @Test
-    public void buildWrapperOnSlave() throws Exception
+    public void dataIsSetWhenEnabledViaJobPropertyOnSlave() throws Exception
     {
         project.addProperty(new LogstashJobProperty());
         project.setAssignedNode(slave);
@@ -103,7 +103,7 @@ public class LogstashIntegrationTest
     }
 
     @Test
-    public void buildNotifierOnMaster() throws Exception
+    public void dataIsSetForNotifierOnMaster() throws Exception
     {
         project.getPublishersList().add(new LogstashNotifier(10, false));
         QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
@@ -118,7 +118,7 @@ public class LogstashIntegrationTest
     }
 
     @Test
-    public void buildNotifierOnSlave() throws Exception
+    public void dataIsSetForNotifierOnSlave() throws Exception
     {
         project.getPublishersList().add(new LogstashNotifier(10, false));
         project.setAssignedNode(slave);

--- a/src/test/resources/buildWrapperConfig.xml
+++ b/src/test/resources/buildWrapperConfig.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers>
+	<jenkins.plugins.logstash.LogstashBuildWrapper plugin="logstash@2.0.0-SNAPSHOT"/>
+  </buildWrappers>
+</project>

--- a/src/test/resources/buildWrapperConfig.xml
+++ b/src/test/resources/buildWrapperConfig.xml
@@ -2,6 +2,7 @@
 <project>
   <actions/>
   <description></description>
+  <properties/>
   <keepDependencies>false</keepDependencies>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>

--- a/src/test/resources/home/jobs/test/config.xml
+++ b/src/test/resources/home/jobs/test/config.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers>
+	<jenkins.plugins.logstash.LogstashBuildWrapper plugin="logstash@2.0.0-SNAPSHOT"/>
+  </buildWrappers>
+</project>


### PR DESCRIPTION
Move from a BuildWrapper to a JobProperty to indicate we want to send to an indexer.
Auto convert to JobProperty after jobs where loaded or when posting xml via the rest api.