### PR TITLE
millisecond timestamps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,12 @@
     	<version>1.15</version>
   		<optional>true</optional>
     </dependency>
+    <dependency>
+    	<groupId>org.hamcrest</groupId>
+    	<artifactId>java-hamcrest</artifactId>
+    	<version>2.0.0.0</version>
+    	<scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
@@ -33,8 +33,8 @@ import net.sf.json.JSONObject;
 public class LogstashConfiguration extends GlobalConfiguration
 {
   private static final Logger LOGGER = Logger.getLogger(LogstashConfiguration.class.getName());
-
-  private transient FastDateFormat dateFormatter;
+  private static final FastDateFormat MILLIS_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+  private static final FastDateFormat LEGACY_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ");
 
   private LogstashIndexer<?> logstashIndexer;
   private boolean dataMigrated = false;
@@ -66,27 +66,17 @@ public class LogstashConfiguration extends GlobalConfiguration
   public void setMilliSecondTimestamps(boolean milliSecondTimestamps)
   {
     this.milliSecondTimestamps = milliSecondTimestamps;
-    createDateFormatter();
   }
 
   public FastDateFormat getDateFormatter()
   {
-    if (dateFormatter == null)
-    {
-      createDateFormatter();
-    }
-    return dateFormatter;
-  }
-
-  private void createDateFormatter()
-  {
     if (milliSecondTimestamps)
     {
-      dateFormatter = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+      return MILLIS_FORMATTER;
     }
     else
     {
-      dateFormatter = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ");
+      return LEGACY_FORMATTER;
     }
   }
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -28,8 +28,7 @@ import java.nio.charset.Charset;
 import java.util.Calendar;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
-
+import jenkins.plugins.logstash.LogstashConfiguration;
 import net.sf.json.JSONObject;
 
 /**
@@ -72,9 +71,10 @@ public abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
     payload.put("source", "jenkins");
     payload.put("source_host", jenkinsUrl);
     payload.put("@buildTimestamp", buildData.getTimestamp());
-    payload.put("@timestamp", BuildData.getDateFormatter().format(Calendar.getInstance().getTime()));
+    payload.put("@timestamp", LogstashConfiguration.getInstance().getDateFormatter().format(Calendar.getInstance().getTime()));
     payload.put("@version", 1);
 
     return payload;
   }
+
 }

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -34,6 +34,7 @@ import hudson.model.Run;
 import hudson.model.Node;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
+import jenkins.plugins.logstash.LogstashConfiguration;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -51,7 +52,6 @@ import java.lang.invoke.MethodHandles;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.time.FastDateFormat;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -64,7 +64,6 @@ import com.google.gson.GsonBuilder;
  */
 public class BuildData {
   // ISO 8601 date format
-  private transient static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ");
   private final static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getCanonicalName());
   public static class TestData {
     private int totalCount, skipCount, failCount, passCount;
@@ -263,7 +262,7 @@ public class BuildData {
     }
 
     buildDuration = currentTime.getTime() - build.getStartTimeInMillis();
-    timestamp = DATE_FORMATTER.format(build.getTimestamp().getTime());
+    timestamp = LogstashConfiguration.getInstance().getDateFormatter().format(build.getTimestamp().getTime());
   }
 
   @Override
@@ -378,7 +377,7 @@ public class BuildData {
   }
 
   public void setTimestamp(Calendar timestamp) {
-    this.timestamp = DATE_FORMATTER.format(timestamp.getTime());
+    this.timestamp = LogstashConfiguration.getInstance().getDateFormatter().format(timestamp.getTime());
   }
 
   public String getRootProjectName() {
@@ -435,10 +434,5 @@ public class BuildData {
 
   public void setTestResults(TestData testResults) {
     this.testResults = testResults;
-  }
-
-  public static FastDateFormat getDateFormatter()
-  {
-    return DATE_FORMATTER;
   }
 }

--- a/src/main/java/jenkins/plugins/logstash/persistence/HostBasedLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/HostBasedLogstashIndexerDao.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 
+import jenkins.plugins.logstash.LogstashConfiguration;
 import net.sf.json.JSONObject;
 
 /**
@@ -78,7 +79,7 @@ public abstract class HostBasedLogstashIndexerDao extends AbstractLogstashIndexe
     payload.put("source", "jenkins");
     payload.put("source_host", jenkinsUrl);
     payload.put("@buildTimestamp", buildData.getTimestamp());
-    payload.put("@timestamp", BuildData.getDateFormatter().format(Calendar.getInstance().getTime()));
+    payload.put("@timestamp", LogstashConfiguration.getInstance().getDateFormatter().format(Calendar.getInstance().getTime()));
     payload.put("@version", 1);
 
     return payload;

--- a/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/config.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/config.jelly
@@ -7,5 +7,8 @@
     <f:entry title="Enable Globally" field="enableGlobally" description="This will not enable it for pipeline jobs.">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="Use millisecond time stamps" field="milliSecondTimestamps">
+    	<f:checkbox default="true"/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/help-milliSecondTimestamps.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/help-milliSecondTimestamps.html
@@ -1,0 +1,2 @@
+Use time stamps that include the milliseconds of the event. This should ensure that the indexer will keep the order of events when 
+they arrive in the same second.

--- a/src/test/java/jenkins/plugins/logstash/LogstashConfigurationMigrationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashConfigurationMigrationTest.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Before;
@@ -69,6 +68,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     configuration.migrateData();
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(Redis.class));
+    assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
     Redis redis = (Redis) indexer;
     assertThat(redis.getHost(),equalTo("localhost"));
     assertThat(redis.getPort(),is(4567));
@@ -84,6 +84,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     configuration.migrateData();
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(Syslog.class));
+    assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
     Syslog syslog = (Syslog) indexer;
     assertThat(syslog.getHost(),equalTo("localhost"));
     assertThat(syslog.getPort(),is(4567));
@@ -98,6 +99,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     configuration.migrateData();
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(Syslog.class));
+    assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
     Syslog syslog = (Syslog) indexer;
     assertThat(syslog.getHost(),equalTo("localhost"));
     assertThat(syslog.getPort(),is(4567));
@@ -112,6 +114,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     configuration.migrateData();
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(ElasticSearch.class));
+    assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
     ElasticSearch es = (ElasticSearch) indexer;
     URI uri = new URI("http://localhost:4567/logstash");
     assertThat(es.getUri(),equalTo(uri));
@@ -126,6 +129,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     configuration.migrateData();
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(RabbitMq.class));
+    assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
     RabbitMq es = (RabbitMq) indexer;
     assertThat(es.getHost(),equalTo("localhost"));
     assertThat(es.getPort(),is(4567));

--- a/src/test/java/jenkins/plugins/logstash/LogstashConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashConfigurationTest.java
@@ -1,10 +1,13 @@
 package jenkins.plugins.logstash;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
+import java.util.Date;
 
+import org.apache.commons.lang.time.FastDateFormat;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
 
@@ -54,5 +57,15 @@ public class LogstashConfigurationTest extends LogstashConfigurationTestBase
     LogstashConfigurationTestBase.configFile = new File("src/test/resources/syslog.xml");
     LogstashConfiguration configuration = new LogstashConfigurationForTest();
     assertThat(configuration.getIndexerInstance(), IsInstanceOf.instanceOf(SyslogDao.class));
+  }
+
+  @Test
+  public void millSecondsConfigured()
+  {
+    LogstashConfigurationTestBase.configFile = new File("src/test/resources/rabbitmq.xml");
+    LogstashConfiguration configuration = new LogstashConfigurationForTest();
+    assertThat(configuration.isMilliSecondTimestamps(),equalTo(true));
+    FastDateFormat formatter = configuration.getDateFormatter();
+    assertThat(formatter.format(new Date(118,02,10,22,22)), matchesPattern("2018-03-10T22:22:00.000[+-]\\d{4}"));
   }
 }

--- a/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
@@ -7,11 +7,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.time.FastDateFormat;
 import org.jenkinsci.plugins.envinject.EnvInjectBuildWrapper;
 import org.jenkinsci.plugins.envinject.EnvInjectJobPropertyInfo;
 import org.junit.Before;
@@ -60,9 +60,11 @@ public class LogstashIntegrationTest
     {
         memoryDao = new MemoryDao();
         PowerMockito.mockStatic(LogstashConfiguration.class);
+
         when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
         when(logstashConfiguration.getIndexerInstance()).thenReturn(memoryDao);
-        when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ"));
+        PowerMockito.doCallRealMethod().when(logstashConfiguration).setMilliSecondTimestamps(any(Boolean.class));
+        when(logstashConfiguration.getDateFormatter()).thenCallRealMethod();
 
         slave = jenkins.createSlave();
         slave.setLabelString("myLabel");
@@ -237,7 +239,7 @@ public class LogstashIntegrationTest
     @Test
     public void milliSecondTimestamps() throws Exception
     {
-      when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
+      logstashConfiguration.setMilliSecondTimestamps(true);
       project.getBuildWrappersList().add(new LogstashBuildWrapper());
       QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
 
@@ -254,7 +256,7 @@ public class LogstashIntegrationTest
     @Test
     public void secondTimestamps() throws Exception
     {
-      when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ"));
+      logstashConfiguration.setMilliSecondTimestamps(false);
       project.getBuildWrappersList().add(new LogstashBuildWrapper());
       QueueTaskFuture<FreeStyleBuild> f = project.scheduleBuild2(0);
 

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -5,12 +5,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyListOf;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -21,16 +23,19 @@ import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.apache.commons.lang.time.FastDateFormat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
@@ -44,7 +49,9 @@ import jenkins.plugins.logstash.persistence.BuildData;
 import jenkins.plugins.logstash.persistence.LogstashIndexerDao;
 import net.sf.json.JSONObject;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
+@PrepareForTest(LogstashConfiguration.class)
 public class LogstashWriterTest {
   // Extension of the unit under test that avoids making calls to getInstance() to get the DAO singleton
   static LogstashWriter createLogstashWriter(final AbstractBuild<?, ?> testBuild,
@@ -83,6 +90,8 @@ public class LogstashWriterTest {
   @Mock AbstractBuild mockBuild;
   @Mock AbstractTestResultAction mockTestResultAction;
   @Mock Project mockProject;
+  @Mock LogstashConfiguration logstashConfiguration;
+
 
   @Mock BuildData mockBuildData;
   @Mock TaskListener mockListener;
@@ -94,6 +103,10 @@ public class LogstashWriterTest {
 
   @Before
   public void before() throws Exception {
+
+    PowerMockito.mockStatic(LogstashConfiguration.class);
+    when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
+    when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ"));
 
     when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
     when(mockBuild.getDisplayName()).thenReturn("LogstashNotifierTest");
@@ -122,10 +135,10 @@ public class LogstashWriterTest {
     when(mockProject.getName()).thenReturn("LogstashWriterTest");
     when(mockProject.getFullName()).thenReturn("parent/LogstashWriterTest");
 
-    when(mockDao.buildPayload(Matchers.any(BuildData.class), Matchers.anyString(), Matchers.anyListOf(String.class)))
+    when(mockDao.buildPayload(any(BuildData.class), anyString(), anyListOf(String.class)))
       .thenReturn(JSONObject.fromObject("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}"));
 
-    Mockito.doNothing().when(mockDao).push(Matchers.anyString());
+    Mockito.doNothing().when(mockDao).push(anyString());
     when(mockDao.getDescription()).thenReturn("localhost:8080");
 
     errorBuffer = new ByteArrayOutputStream();
@@ -239,7 +252,7 @@ public class LogstashWriterTest {
     // No error output
     assertEquals("Results don't match", "", errorBuffer.toString());
 
-    verify(mockDao).buildPayload(Matchers.eq(mockBuildData), Matchers.eq("http://my-jenkins-url"), Matchers.anyListOf(String.class));
+    verify(mockDao).buildPayload(eq(mockBuildData), eq("http://my-jenkins-url"), anyListOf(String.class));
     verify(mockDao).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
     verify(mockDao).setCharset(Charset.defaultCharset());
     verify(mockBuild).getCharset();
@@ -259,7 +272,7 @@ public class LogstashWriterTest {
     verify(mockBuild).getLog(3);
     verify(mockBuild).getCharset();
 
-    verify(mockDao).buildPayload(Matchers.eq(mockBuildData), Matchers.eq("http://my-jenkins-url"), Matchers.anyListOf(String.class));
+    verify(mockDao).buildPayload(eq(mockBuildData), eq("http://my-jenkins-url"), anyListOf(String.class));
     verify(mockDao).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
     verify(mockDao).setCharset(Charset.defaultCharset());
   }
@@ -302,7 +315,7 @@ public class LogstashWriterTest {
     assertEquals("Results don't match", "", errorBuffer.toString());
 
     //Verify calls were made to the dao logging twice, not three times.
-    verify(mockDao, times(2)).buildPayload(Matchers.eq(mockBuildData), Matchers.eq("http://my-jenkins-url"), Matchers.anyListOf(String.class));
+    verify(mockDao, times(2)).buildPayload(eq(mockBuildData), eq("http://my-jenkins-url"), anyListOf(String.class));
     verify(mockDao, times(2)).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
     verify(mockDao, times(2)).getDescription();
     verify(mockDao).setCharset(Charset.defaultCharset());

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -106,7 +106,7 @@ public class LogstashWriterTest {
 
     PowerMockito.mockStatic(LogstashConfiguration.class);
     when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
-    when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ"));
+    when(logstashConfiguration.getDateFormatter()).thenCallRealMethod();
 
     when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
     when(mockBuild.getDisplayName()).thenReturn("LogstashNotifierTest");

--- a/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
@@ -1,7 +1,7 @@
 package jenkins.plugins.logstash.persistence;
 
 import static net.sf.json.test.JSONAssert.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -9,22 +9,35 @@ import java.util.Arrays;
 
 import net.sf.json.JSONObject;
 
+import org.apache.commons.lang.time.FastDateFormat;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+import jenkins.plugins.logstash.LogstashConfiguration;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
+@PrepareForTest(LogstashConfiguration.class)
 public class AbstractLogstashIndexerDaoTest {
   static final String EMPTY_STRING = "{\"@buildTimestamp\":\"2000-01-01\",\"data\":{},\"message\":[],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
   static final String ONE_LINE_STRING = "{\"@buildTimestamp\":\"2000-01-01\",\"data\":{},\"message\":[\"LINE 1\"],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
   static final String TWO_LINE_STRING = "{\"@buildTimestamp\":\"2000-01-01\",\"data\":{},\"message\":[\"LINE 1\", \"LINE 2\"],\"source\":\"jenkins\",\"source_host\":\"http://localhost:8080/jenkins\",\"@version\":1}";
 
   @Mock BuildData mockBuildData;
+  @Mock LogstashConfiguration logstashConfiguration;
 
   @Before
   public void before() throws Exception {
+    PowerMockito.mockStatic(LogstashConfiguration.class);
+    when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
+    when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ"));
+
     when(mockBuildData.toJson()).thenReturn(JSONObject.fromObject("{}"));
     when(mockBuildData.getTimestamp()).thenReturn("2000-01-01");
   }

--- a/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
@@ -1,6 +1,7 @@
 package jenkins.plugins.logstash.persistence;
 
 import static net.sf.json.test.JSONAssert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.IOException;
@@ -36,7 +37,7 @@ public class AbstractLogstashIndexerDaoTest {
   public void before() throws Exception {
     PowerMockito.mockStatic(LogstashConfiguration.class);
     when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
-    when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ"));
+    when(logstashConfiguration.getDateFormatter()).thenCallRealMethod();
 
     when(mockBuildData.toJson()).thenReturn(JSONObject.fromObject("{}"));
     when(mockBuildData.getTimestamp()).thenReturn("2000-01-01");

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.logstash.persistence;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -80,7 +81,7 @@ public class BuildDataTest {
 
     PowerMockito.mockStatic(LogstashConfiguration.class);
     when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
-    when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ"));
+    when(logstashConfiguration.getDateFormatter()).thenCallRealMethod();
 
     when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
     when(mockBuild.getDisplayName()).thenReturn("BuildData Test");

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -4,7 +4,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.apache.commons.lang.time.FastDateFormat;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,8 +24,11 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
@@ -38,12 +42,15 @@ import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
+import jenkins.plugins.logstash.LogstashConfiguration;
 import jenkins.plugins.logstash.persistence.BuildData.TestData;
 import net.sf.json.JSONObject;
 import net.sf.json.test.JSONAssert;
 
 @SuppressWarnings("rawtypes")
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
+@PrepareForTest(LogstashConfiguration.class)
 public class BuildDataTest {
 
   static final String FULL_STRING = "{\"id\":\"TEST_JOB_123\",\"result\":\"SUCCESS\",\"fullProjectName\":\"parent/BuildDataTest\","
@@ -66,10 +73,15 @@ public class BuildDataTest {
   @Mock TaskListener mockListener;
   @Mock Computer mockComputer;
   @Mock Executor mockExecutor;
-
+  @Mock LogstashConfiguration logstashConfiguration;
 
   @Before
   public void before() throws Exception {
+
+    PowerMockito.mockStatic(LogstashConfiguration.class);
+    when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
+    when(logstashConfiguration.getDateFormatter()).thenReturn(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ"));
+
     when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
     when(mockBuild.getDisplayName()).thenReturn("BuildData Test");
     when(mockBuild.getFullDisplayName()).thenReturn("BuildData Test #123456");

--- a/src/test/resources/rabbitmq.xml
+++ b/src/test/resources/rabbitmq.xml
@@ -7,4 +7,5 @@
     <password>{AQAAABAAAAAQ5wlElDfWGri9VuaMh0MCBZWs1fjL31zvnxrkszfW5pA=}</password>
   </logstashIndexer>
   <dataMigrated>true</dataMigrated>
+  <milliSecondTimestamps>true</milliSecondTimestamps>
 </jenkins.plugins.logstash.LogstashConfiguration>


### PR DESCRIPTION
With a precision of only seconds, indexers might not be able to properly
order the logs when using the ConsoleLogFilter.
Use by default timestamps with milliseconds precision for new installations of the plugin.
When migrating from old ToolInstallation way of configuration,
millisecond precision is turned of to avoid possible problems with
existing setups.