### PR TITLE
charset for rabbitMQ

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
@@ -156,8 +156,8 @@ public class LogstashConfiguration extends GlobalConfiguration
             }
             break;
           case RABBIT_MQ:
-            LOGGER.log(Level.INFO, "Migrating logstash configuration for  RabbitMQ");
-            RabbitMq rabbitMq = new RabbitMq();
+            LOGGER.log(Level.INFO, "Migrating logstash configuration for RabbitMQ");
+            RabbitMq rabbitMq = new RabbitMq("");
             rabbitMq.setHost(descriptor.getHost());
             rabbitMq.setPort(descriptor.getPort());
             rabbitMq.setQueue(descriptor.getKey());

--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -64,9 +64,6 @@ public class LogstashWriter {
   private boolean connectionBroken;
   private Charset charset;
 
-  /*
-   * TODO: the charset must not be transfered to the dao. The dao is shared between different build.
-   */
   public LogstashWriter(Run<?, ?> run, OutputStream error, TaskListener listener, Charset charset) {
     this.errorStream = error != null ? error : System.err;
     this.build = run;
@@ -79,7 +76,6 @@ public class LogstashWriter {
     } else {
       this.jenkinsUrl = getJenkinsUrl();
       this.buildData = getBuildData();
-      dao.setCharset(charset);
     }
   }
 

--- a/src/main/java/jenkins/plugins/logstash/configuration/RabbitMq.java
+++ b/src/main/java/jenkins/plugins/logstash/configuration/RabbitMq.java
@@ -1,5 +1,7 @@
 package jenkins.plugins.logstash.configuration;
 
+import java.nio.charset.Charset;
+
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -17,10 +19,34 @@ public class RabbitMq extends HostBasedLogstashIndexer<RabbitMqDao>
   private String queue;
   private String username;
   private Secret password;
+  private Charset charset;
+
 
   @DataBoundConstructor
-  public RabbitMq()
+  public RabbitMq(String charset)
   {
+    if (charset == null || charset.isEmpty())
+    {
+      this.charset = Charset.defaultCharset();
+    }
+    else
+    {
+      this.charset = Charset.forName(charset);
+    }
+  }
+
+  protected Object readResolve()
+  {
+    if (charset == null)
+    {
+      charset = Charset.defaultCharset();
+    }
+    return this;
+  }
+
+  public Charset getCharset()
+  {
+    return charset;
   }
 
   public String getQueue()
@@ -105,7 +131,7 @@ public class RabbitMq extends HostBasedLogstashIndexer<RabbitMqDao>
   @Override
   public RabbitMqDao createIndexerInstance()
   {
-    return new RabbitMqDao(getHost(), getPort(), queue, username, Secret.toString(password));
+    return new RabbitMqDao(getHost(), getPort(), queue, username, Secret.toString(password), charset);
   }
 
   @Extension

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -24,7 +24,6 @@
 
 package jenkins.plugins.logstash.persistence;
 
-import java.nio.charset.Charset;
 import java.util.Calendar;
 import java.util.List;
 
@@ -34,34 +33,10 @@ import net.sf.json.JSONObject;
 /**
  * Abstract data access object for Logstash indexers.
  *
- * TODO: a charset is only required for RabbitMq currently (ES as well but there it is currently configured via the ContentType),
- *   so better move this to the corresponding classes.
  * @author Rusty Gerard
  * @since 1.0.0
  */
 public abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
-  private Charset charset;
-
-  /**
-   * Sets the charset used to push data to the indexer
-   *
-   *@param charset The charset to push data
-   */
-  @Override
-  public void setCharset(Charset charset)
-  {
-    this.charset = charset;
-  }
-
-  /**
-   * Gets the configured charset used to push data to the indexer
-   *
-   * @return charste to push data
-   */
-  public Charset getCharset()
-  {
-    return charset;
-  }
 
   @Override
   public JSONObject buildPayload(BuildData buildData, String jenkinsUrl, List<String> logLines) {

--- a/src/main/java/jenkins/plugins/logstash/persistence/HostBasedLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/HostBasedLogstashIndexerDao.java
@@ -39,7 +39,6 @@ import net.sf.json.JSONObject;
 public abstract class HostBasedLogstashIndexerDao extends AbstractLogstashIndexerDao {
   private final String host;
   private final int port;
-  private Charset charset;
 
   public HostBasedLogstashIndexerDao(String host, int port) {
     this.host = host;
@@ -47,28 +46,6 @@ public abstract class HostBasedLogstashIndexerDao extends AbstractLogstashIndexe
     if (StringUtils.isBlank(host)) {
       throw new IllegalArgumentException("host name is required");
     }
-  }
-
-  /**
-   * Sets the charset used to push data to the indexer
-   *
-   *@param charset The charset to push data
-   */
-  @Override
-  public void setCharset(Charset charset)
-  {
-    this.charset = charset;
-  }
-
-  /**
-   * Gets the configured charset used to push data to the indexer
-   *
-   * @return charste to push data
-   */
-  @Override
-  public Charset getCharset()
-  {
-    return charset;
   }
 
   @Override

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashIndexerDao.java
@@ -55,8 +55,6 @@ public interface LogstashIndexerDao {
 	UDP
   }
 
-  public void setCharset(Charset charset);
-
   public String getDescription();
 
   /**

--- a/src/main/resources/jenkins/plugins/logstash/configuration/RabbitMq/configure-advanced.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/configuration/RabbitMq/configure-advanced.jelly
@@ -9,4 +9,7 @@
     <f:entry title="${%Queue}" field="queue">
       <f:textbox default="logstash"/>
     </f:entry>
+    <f:entry title="${%Charset}" field="charset">
+      <f:textbox default="UTF-8"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/logstash/configuration/RabbitMq/help-charset.html
+++ b/src/main/resources/jenkins/plugins/logstash/configuration/RabbitMq/help-charset.html
@@ -1,0 +1,5 @@
+<div>
+  <p>The charset to use when publishing to the RabbitMQ server.<br/>
+  Leave empty to use the default charset.
+  </p>
+</div>

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -179,7 +179,6 @@ public class LogstashWriterTest {
     verify(mockBuild).getEnvironments();
     verify(mockBuild).getEnvironment(null);
     verify(mockBuild).getCharset();
-    verify(mockDao).setCharset(Charset.defaultCharset());
 
     verify(mockTestResultAction).getTotalCount();
     verify(mockTestResultAction).getSkipCount();
@@ -254,7 +253,6 @@ public class LogstashWriterTest {
 
     verify(mockDao).buildPayload(eq(mockBuildData), eq("http://my-jenkins-url"), anyListOf(String.class));
     verify(mockDao).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
-    verify(mockDao).setCharset(Charset.defaultCharset());
     verify(mockBuild).getCharset();
   }
 
@@ -274,7 +272,6 @@ public class LogstashWriterTest {
 
     verify(mockDao).buildPayload(eq(mockBuildData), eq("http://my-jenkins-url"), anyListOf(String.class));
     verify(mockDao).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
-    verify(mockDao).setCharset(Charset.defaultCharset());
   }
 
   @Test
@@ -318,7 +315,6 @@ public class LogstashWriterTest {
     verify(mockDao, times(2)).buildPayload(eq(mockBuildData), eq("http://my-jenkins-url"), anyListOf(String.class));
     verify(mockDao, times(2)).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
     verify(mockDao, times(2)).getDescription();
-    verify(mockDao).setCharset(Charset.defaultCharset());
     verify(mockBuild).getCharset();
   }
 
@@ -342,7 +338,6 @@ public class LogstashWriterTest {
       "java.io.IOException: Unable to read log file");
     verify(mockDao).push("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}");
     verify(mockDao).buildPayload(eq(mockBuildData), eq("http://my-jenkins-url"), logLinesCaptor.capture());
-    verify(mockDao).setCharset(Charset.defaultCharset());
     List<String> actualLogLines = logLinesCaptor.getValue();
 
     assertThat("The exception was not sent to Logstash", actualLogLines.get(0), containsString(expectedErrorLines.get(0)));

--- a/src/test/java/jenkins/plugins/logstash/configuration/RabbitMqTest.java
+++ b/src/test/java/jenkins/plugins/logstash/configuration/RabbitMqTest.java
@@ -20,14 +20,14 @@ public class RabbitMqTest
   @Before
   public void setup()
   {
-    indexer = new RabbitMq();
+    indexer = new RabbitMq("UTF-8");
     indexer.setHost("localhost");
     indexer.setPort(4567);
     indexer.setPassword("password");
     indexer.setUsername("user");
     indexer.setQueue("queue");
 
-    indexer2 = new RabbitMq();
+    indexer2 = new RabbitMq("UTF-8");
     indexer2.setHost("localhost");
     indexer2.setPort(4567);
     indexer2.setPassword("password");

--- a/src/test/java/jenkins/plugins/logstash/persistence/RabbitMqDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/RabbitMqDaoTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.net.SocketException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -29,7 +30,7 @@ public class RabbitMqDaoTest {
   @Mock Channel mockChannel;
 
   RabbitMqDao createDao(String host, int port, String key, String username, String password) {
-    RabbitMqDao factory = new RabbitMqDao(mockPool, host, port, key, username, password);
+    RabbitMqDao factory = new RabbitMqDao(mockPool, host, port, key, username, password, StandardCharsets.UTF_8);
     verify(mockPool, atLeastOnce()).setHost(host);
     verify(mockPool, atLeastOnce()).setPort(port);
 
@@ -37,8 +38,6 @@ public class RabbitMqDaoTest {
       verify(mockPool, atLeastOnce()).setUsername(username);
       verify(mockPool, atLeastOnce()).setPassword(password);
     }
-
-    factory.setCharset(Charset.defaultCharset());
 
     return factory;
   }
@@ -48,7 +47,6 @@ public class RabbitMqDaoTest {
     int port = (int) (Math.random() * 1000);
     // Note that we can't run these tests in parallel
     dao = createDao("localhost", port, "logstash", "username", "password");
-    dao.setCharset(Charset.defaultCharset());
 
     when(mockPool.newConnection()).thenReturn(mockConnection);
 
@@ -199,7 +197,6 @@ public class RabbitMqDaoTest {
   public void pushSuccessNoAuth() throws Exception {
     String json = "{ 'foo': 'bar' }";
     dao = createDao("localhost", 5672, "logstash", null, null);
-    dao.setCharset(Charset.defaultCharset());
 
     // Unit under test
     dao.push(json);


### PR DESCRIPTION
we passed the charset from the build to the Dao and used it in
RabbitMQ. This is wrong.
The dao is used by multiple builds in parallel, if a new build uses a
different charset (pipeline uses UTF-8 while freestyle use the default
charset) we change it for running builds
RabbitMQ stores the data in binary form so we need a charset. But the
consumer needs to know which charset is used, so we should make this
configurable.