### PR TITLE
[JENKINS-42536] fix ansi console note

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,12 @@
     	<version>2.0.0.0</version>
     	<scope>test</scope>
     </dependency>
+    <dependency>
+    	<groupId>org.jenkins-ci.plugins</groupId>
+    	<artifactId>ansicolor</artifactId>
+    	<version>0.5.2</version>
+    	<scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/jenkins/plugins/logstash/LogstashOutputStream.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashOutputStream.java
@@ -59,8 +59,8 @@ public class LogstashOutputStream extends LineTransformationOutputStream {
     this.flush();
 
     if(!logstash.isConnectionBroken()) {
-      String line = new String(b, 0, len, logstash.getCharset()).trim();
-      line = ConsoleNote.removeNotes(line);
+      String line = new String(b, 0, len, logstash.getCharset());
+      line = ConsoleNote.removeNotes(line).trim();
       logstash.write(line);
     }
   }


### PR DESCRIPTION
when a line starts with a console note we trimmed the leading escape
character before passing it to the removeNotes method. This makes it not
recognize as a console note.
So trim after removing the notes.