### PR TITLE
[JENKINS-51793] explicit enable

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
@@ -146,7 +146,6 @@ public class LogstashConfiguration extends GlobalConfiguration
       if (descriptor.getType() != null)
       {
         IndexerType type = descriptor.getType();
-        enabled = true;
         switch (type)
         {
           case REDIS:
@@ -157,6 +156,7 @@ public class LogstashConfiguration extends GlobalConfiguration
             redis.setKey(descriptor.getKey());
             redis.setPassword(descriptor.getPassword());
             logstashIndexer = redis;
+            enabled = true;
             break;
           case ELASTICSEARCH:
             LOGGER.log(Level.INFO, "Migrating logstash configuration for Elastic Search");
@@ -171,9 +171,11 @@ public class LogstashConfiguration extends GlobalConfiguration
               es.setUsername(descriptor.getUsername());
               es.setPassword(descriptor.getPassword());
               logstashIndexer = es;
+              enabled = true;
             }
             catch (URISyntaxException e)
             {
+              enabled = false;
               LOGGER.log(Level.INFO, "Migrating logstash configuration for Elastic Search failed: " + e.toString());
             }
             break;
@@ -186,6 +188,7 @@ public class LogstashConfiguration extends GlobalConfiguration
             rabbitMq.setUsername(descriptor.getUsername());
             rabbitMq.setPassword(descriptor.getPassword());
             logstashIndexer = rabbitMq;
+            enabled = true;
             break;
           case SYSLOG:
             LOGGER.log(Level.INFO, "Migrating logstash configuration for  SYSLOG");
@@ -206,6 +209,7 @@ public class LogstashConfiguration extends GlobalConfiguration
                 break;
             }
             logstashIndexer = syslog;
+            enabled = true;
             break;
           default:
             LOGGER.log(Level.INFO, "unknown logstash Indexer type: " + type);

--- a/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
@@ -62,7 +62,7 @@ public class LogstashConfiguration extends GlobalConfiguration
 
   public boolean isEnabled()
   {
-    return enabled;
+    return enabled == null ? false: enabled;
   }
 
   public void setEnabled(boolean enabled)

--- a/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
@@ -37,6 +37,7 @@ public class LogstashConfiguration extends GlobalConfiguration
   private static final FastDateFormat LEGACY_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZ");
 
   private LogstashIndexer<?> logstashIndexer;
+  private Boolean enabled;
   private boolean dataMigrated = false;
   private boolean enableGlobally = false;
   private boolean milliSecondTimestamps = true;
@@ -45,7 +46,28 @@ public class LogstashConfiguration extends GlobalConfiguration
   public LogstashConfiguration()
   {
     load();
+    if (enabled == null)
+    {
+      if (logstashIndexer == null)
+      {
+        enabled = false;
+      }
+      else
+      {
+        enabled = true;
+      }
+    }
     activeIndexer = logstashIndexer;
+  }
+
+  public boolean isEnabled()
+  {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled)
+  {
+    this.enabled = enabled;
   }
 
   public boolean isEnableGlobally()
@@ -124,6 +146,7 @@ public class LogstashConfiguration extends GlobalConfiguration
       if (descriptor.getType() != null)
       {
         IndexerType type = descriptor.getType();
+        enabled = true;
         switch (type)
         {
           case REDIS:
@@ -186,6 +209,7 @@ public class LogstashConfiguration extends GlobalConfiguration
             break;
           default:
             LOGGER.log(Level.INFO, "unknown logstash Indexer type: " + type);
+            enabled = false;
             break;
         }
         milliSecondTimestamps = false;

--- a/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
@@ -3,6 +3,8 @@ package jenkins.plugins.logstash;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import hudson.Extension;
 import hudson.console.ConsoleLogFilter;
@@ -13,6 +15,8 @@ import hudson.model.Run;
 @Extension(ordinal = 1000)
 public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serializable
 {
+
+  private static Logger LOGGER = Logger.getLogger(LogstashConsoleLogFilter.class.getName());
 
   private transient Run<?, ?> run;
   public LogstashConsoleLogFilter() {};
@@ -29,6 +33,7 @@ public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serial
     LogstashConfiguration configuration = LogstashConfiguration.getInstance();
     if (!configuration.isEnabled())
     {
+      LOGGER.log(Level.FINE, "Logstash is disabled. Logs will not be forwarded.");
       return logger;
     }
 

--- a/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
@@ -26,6 +26,12 @@ public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serial
   @Override
   public OutputStream decorateLogger(Run build, OutputStream logger) throws IOException, InterruptedException
   {
+    LogstashConfiguration configuration = LogstashConfiguration.getInstance();
+    if (!configuration.isEnabled())
+    {
+      return logger;
+    }
+
     if (build != null && build instanceof AbstractBuild<?, ?>)
     {
       if (isLogstashEnabled(build))

--- a/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
@@ -88,6 +88,12 @@ public class LogstashNotifier extends Notifier implements SimpleBuildStep {
   }
 
   private boolean perform(Run<?, ?> run, TaskListener listener) {
+    LogstashConfiguration configuration = LogstashConfiguration.getInstance();
+    if (!configuration.isEnabled())
+    {
+      return true;
+    }
+
     PrintStream errorPrintStream = listener.getLogger();
     LogstashWriter logstash = getLogStashWriter(run, errorPrintStream, listener);
     logstash.writeBuildLog(maxLines);

--- a/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
@@ -41,6 +41,8 @@ import hudson.util.FormValidation;
 import jenkins.tasks.SimpleBuildStep;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.io.IOException;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -54,6 +56,8 @@ import org.jenkinsci.Symbol;
  * @since 1.0.0
  */
 public class LogstashNotifier extends Notifier implements SimpleBuildStep {
+
+  private static Logger LOGGER = Logger.getLogger(LogstashNotifier.class.getName());
 
   private int maxLines;
   private boolean failBuild;
@@ -91,6 +95,7 @@ public class LogstashNotifier extends Notifier implements SimpleBuildStep {
     LogstashConfiguration configuration = LogstashConfiguration.getInstance();
     if (!configuration.isEnabled())
     {
+      LOGGER.log(Level.FINE, "Logstash is disabled. Logs will not be forwarded.");
       return true;
     }
 

--- a/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/config.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/config.jelly
@@ -1,14 +1,16 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="${%Logstash}">
-    <f:entry>
-    	<f:dropdownDescriptorSelector title="${%Indexer Type}" field="logstashIndexer" descriptors="${descriptor.indexerTypes}"/>
-    </f:entry>
-    <f:entry title="Enable Globally" field="enableGlobally" description="This will not enable it for pipeline jobs.">
-      <f:checkbox/>
-    </f:entry>
-    <f:entry title="Use millisecond time stamps" field="milliSecondTimestamps">
-    	<f:checkbox default="true"/>
-    </f:entry>
+    <f:optionalBlock name="enabled" title="Enable sending logs to an Indexer" inline="true" field="enabled">
+	    <f:entry>
+	    	<f:dropdownDescriptorSelector title="${%Indexer Type}" field="logstashIndexer" descriptors="${descriptor.indexerTypes}"/>
+	    </f:entry>
+	    <f:entry title="Enable Globally" field="enableGlobally" description="This will not enable it for pipeline jobs.">
+	      <f:checkbox/>
+	    </f:entry>
+	    <f:entry title="Use millisecond time stamps" field="milliSecondTimestamps">
+	    	<f:checkbox default="true"/>
+	    </f:entry>
+    </f:optionalBlock>
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/help-enabled.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/help-enabled.html
@@ -1,0 +1,1 @@
+By enabling logstash you can send the log output to various indexers like <em>Elastic Search</em> or <em>RabbitMQ</em> (See help of Indexer Type).

--- a/src/test/java/jenkins/plugins/logstash/LogstashConfigurationMigrationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashConfigurationMigrationTest.java
@@ -62,6 +62,14 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
   }
 
   @Test
+  public void NoConfigMigration()
+  {
+    when(descriptor.getType()).thenReturn(null);
+    configuration.migrateData();
+    assertThat(configuration.isEnabled(),equalTo(false));
+  }
+
+  @Test
   public void redisMigration()
   {
     when(descriptor.getType()).thenReturn(IndexerType.REDIS);
@@ -69,6 +77,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(Redis.class));
     assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
+    assertThat(configuration.isEnabled(),equalTo(true));
     Redis redis = (Redis) indexer;
     assertThat(redis.getHost(),equalTo("localhost"));
     assertThat(redis.getPort(),is(4567));
@@ -85,6 +94,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(Syslog.class));
     assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
+    assertThat(configuration.isEnabled(),equalTo(true));
     Syslog syslog = (Syslog) indexer;
     assertThat(syslog.getHost(),equalTo("localhost"));
     assertThat(syslog.getPort(),is(4567));
@@ -100,6 +110,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(Syslog.class));
     assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
+    assertThat(configuration.isEnabled(),equalTo(true));
     Syslog syslog = (Syslog) indexer;
     assertThat(syslog.getHost(),equalTo("localhost"));
     assertThat(syslog.getPort(),is(4567));
@@ -115,6 +126,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(ElasticSearch.class));
     assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
+    assertThat(configuration.isEnabled(),equalTo(true));
     ElasticSearch es = (ElasticSearch) indexer;
     URI uri = new URI("http://localhost:4567/logstash");
     assertThat(es.getUri(),equalTo(uri));
@@ -130,6 +142,7 @@ public class LogstashConfigurationMigrationTest extends LogstashConfigurationTes
     LogstashIndexer<?> indexer = configuration.getLogstashIndexer();
     assertThat(indexer, IsInstanceOf.instanceOf(RabbitMq.class));
     assertThat(configuration.isMilliSecondTimestamps(),equalTo(false));
+    assertThat(configuration.isEnabled(),equalTo(true));
     RabbitMq es = (RabbitMq) indexer;
     assertThat(es.getHost(),equalTo("localhost"));
     assertThat(es.getPort(),is(4567));

--- a/src/test/java/jenkins/plugins/logstash/LogstashConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashConfigurationTest.java
@@ -25,6 +25,15 @@ public class LogstashConfigurationTest extends LogstashConfigurationTestBase
     LogstashConfigurationTestBase.configFile = new File("src/test/resources/notExisting.xml");
     LogstashConfiguration configuration = new LogstashConfigurationForTest();
     assertThat(configuration.getIndexerInstance(), equalTo(null));
+    assertThat(configuration.isEnabled(), equalTo(false));
+  }
+
+  @Test
+  public void disabled()
+  {
+    LogstashConfigurationTestBase.configFile = new File("src/test/resources/disabled.xml");
+    LogstashConfiguration configuration = new LogstashConfigurationForTest();
+    assertThat(configuration.isEnabled(), equalTo(false));
   }
 
   @Test
@@ -33,6 +42,7 @@ public class LogstashConfigurationTest extends LogstashConfigurationTestBase
     LogstashConfigurationTestBase.configFile = new File("src/test/resources/elasticSearch.xml");
     LogstashConfiguration configuration = new LogstashConfigurationForTest();
     assertThat(configuration.getIndexerInstance(), IsInstanceOf.instanceOf(ElasticSearchDao.class));
+    assertThat(configuration.isEnabled(), equalTo(true));
   }
 
   @Test
@@ -41,6 +51,7 @@ public class LogstashConfigurationTest extends LogstashConfigurationTestBase
     LogstashConfigurationTestBase.configFile = new File("src/test/resources/rabbitmq.xml");
     LogstashConfiguration configuration = new LogstashConfigurationForTest();
     assertThat(configuration.getIndexerInstance(), IsInstanceOf.instanceOf(RabbitMqDao.class));
+    assertThat(configuration.isEnabled(), equalTo(true));
   }
 
   @Test
@@ -49,6 +60,7 @@ public class LogstashConfigurationTest extends LogstashConfigurationTestBase
     LogstashConfigurationTestBase.configFile = new File("src/test/resources/redis.xml");
     LogstashConfiguration configuration = new LogstashConfigurationForTest();
     assertThat(configuration.getIndexerInstance(), IsInstanceOf.instanceOf(RedisDao.class));
+    assertThat(configuration.isEnabled(), equalTo(true));
   }
 
   @Test
@@ -57,6 +69,7 @@ public class LogstashConfigurationTest extends LogstashConfigurationTestBase
     LogstashConfigurationTestBase.configFile = new File("src/test/resources/syslog.xml");
     LogstashConfiguration configuration = new LogstashConfigurationForTest();
     assertThat(configuration.getIndexerInstance(), IsInstanceOf.instanceOf(SyslogDao.class));
+    assertThat(configuration.isEnabled(), equalTo(true));
   }
 
   @Test

--- a/src/test/java/jenkins/plugins/logstash/LogstashConsoloLogFilterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashConsoloLogFilterTest.java
@@ -67,6 +67,7 @@ public class LogstashConsoloLogFilterTest {
     PowerMockito.mockStatic(LogstashConfiguration.class);
     when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
     when(logstashConfiguration.isEnableGlobally()).thenReturn(false);
+    when(logstashConfiguration.isEnabled()).thenReturn(true);
 
     when(mockWriter.isConnectionBroken()).thenReturn(false);
     when(mockBuild.getParent()).thenReturn(mockProject);

--- a/src/test/java/jenkins/plugins/logstash/LogstashNotifierTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashNotifierTest.java
@@ -3,6 +3,8 @@ package jenkins.plugins.logstash;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.when;
+
 import hudson.Launcher;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
@@ -25,12 +27,18 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 @SuppressWarnings("rawtypes")
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
+@PrepareForTest(LogstashConfiguration.class)
 public class LogstashNotifierTest {
+
   // Extension of the unit under test that avoids making calls to Jenkins.getInstance() to get the DAO singleton
   static class MockLogstashNotifier extends LogstashNotifier {
     LogstashWriter writer;
@@ -76,6 +84,9 @@ public class LogstashNotifierTest {
   @Mock Launcher mockLauncher;
   @Mock BuildListener mockListener;
   @Mock AbstractProject mockProject;
+  @Mock private LogstashConfiguration logstashConfiguration;
+
+
 
   ByteArrayOutputStream errorBuffer;
   PrintStream errorStream;
@@ -87,6 +98,11 @@ public class LogstashNotifierTest {
   public void before() throws Exception {
     errorBuffer = new ByteArrayOutputStream();
     errorStream = new PrintStream(errorBuffer, true);
+
+    PowerMockito.mockStatic(LogstashConfiguration.class);
+    when(LogstashConfiguration.getInstance()).thenReturn(logstashConfiguration);
+    when(logstashConfiguration.isEnabled()).thenReturn(true);
+
 
     when(mockProject.assignBuildNumber()).thenReturn(1);
     mockRun = new MockRun(mockProject);

--- a/src/test/resources/disabled.xml
+++ b/src/test/resources/disabled.xml
@@ -1,0 +1,12 @@
+<jenkins.plugins.logstash.LogstashConfiguration plugin="logstash@1.4.0-SNAPSHOT">
+  <logstashIndexer class="jenkins.plugins.logstash.configuration.RabbitMq">
+    <host>localhost</host>
+    <port>5672</port>
+    <queue>logstash</queue>
+    <username></username>
+    <password>{AQAAABAAAAAQ5wlElDfWGri9VuaMh0MCBZWs1fjL31zvnxrkszfW5pA=}</password>
+  </logstashIndexer>
+  <enabled>false</enabled>
+  <dataMigrated>true</dataMigrated>
+  <milliSecondTimestamps>true</milliSecondTimestamps>
+</jenkins.plugins.logstash.LogstashConfiguration>

--- a/src/test/resources/disabled.xml
+++ b/src/test/resources/disabled.xml
@@ -1,4 +1,4 @@
-<jenkins.plugins.logstash.LogstashConfiguration plugin="logstash@1.4.0-SNAPSHOT">
+<jenkins.plugins.logstash.LogstashConfiguration plugin="logstash@2.0.1-SNAPSHOT">
   <logstashIndexer class="jenkins.plugins.logstash.configuration.RabbitMq">
     <host>localhost</host>
     <port>5672</port>


### PR DESCRIPTION
Explicitly enable indexing
When a 1.x version of the plugin was installed but never configured and then one updates to 2.0
the configuration is initially not saveable.
Also when installing the first time one couldn't save without
configuring the plugin. With the enable option it is initially disabled
and one can save without problems.