### PR TITLE
[JENKINS-52693] - Make Build Data and ElasticSearchDao serializable

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -36,6 +36,7 @@ import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 import jenkins.plugins.logstash.LogstashConfiguration;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -62,7 +63,7 @@ import com.google.gson.GsonBuilder;
  * @author Rusty Gerard
  * @since 1.0.0
  */
-public class BuildData {
+public class BuildData implements Serializable {
   // ISO 8601 date format
   private final static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getCanonicalName());
   public static class TestData {


### PR DESCRIPTION
We have returned to the external Logging stories proposed in https://github.com/jenkinsci/logstash-plugin/pull/18.  In order to reduce the complexity of that pull request, I decided to implement a new plugin which would depend on the Logstash plugin instead of bundling all code inside.

Draft of such implementation is here: https://github.com/oleg-nenashev/external-logging-logstash-plugin/tree/JENKINS-52693-plugin-skeleton (to be hosted on Jenkins CI).

This pull request aggregates changes we need in order to implement such integration

- [x] - Make Build Data and ElasticSearchDao serializable

Nice 2 have:
- [ ] - JENKINS-52696- Incrementalify the plugin (to be submitted as a separate PR)
- [ ] - JENKINS-52697 - Integrate the plugin with Configuration-as-Code plugin (to be submitted as a separate PR)

@jglick @carlossg 
