### PR TITLE
[JENKINS-52712] Make compatible with JEP-200

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/configuration/RabbitMq.java
+++ b/src/main/java/jenkins/plugins/logstash/configuration/RabbitMq.java
@@ -19,7 +19,7 @@ public class RabbitMq extends HostBasedLogstashIndexer<RabbitMqDao>
   private String queue;
   private String username;
   private Secret password;
-  private Charset charset;
+  private String charset;
   private String virtualHost;
 
   @DataBoundConstructor
@@ -27,11 +27,11 @@ public class RabbitMq extends HostBasedLogstashIndexer<RabbitMqDao>
   {
     if (charset == null || charset.isEmpty())
     {
-      this.charset = Charset.defaultCharset();
+      this.charset = Charset.defaultCharset().toString();
     }
     else
     {
-      this.charset = Charset.forName(charset);
+      this.charset = Charset.forName(charset).toString();
     }
   }
 
@@ -39,7 +39,7 @@ public class RabbitMq extends HostBasedLogstashIndexer<RabbitMqDao>
   {
     if (charset == null)
     {
-      charset = Charset.defaultCharset();
+      charset = Charset.defaultCharset().toString();
     }
     if (virtualHost == null)
     {
@@ -48,7 +48,7 @@ public class RabbitMq extends HostBasedLogstashIndexer<RabbitMqDao>
     return this;
   }
 
-  public Charset getCharset()
+  public String getCharset()
   {
     return charset;
   }
@@ -153,7 +153,7 @@ public class RabbitMq extends HostBasedLogstashIndexer<RabbitMqDao>
   @Override
   public RabbitMqDao createIndexerInstance()
   {
-    return new RabbitMqDao(getHost(), getPort(), queue, username, Secret.toString(password), charset, getVirtualHost());
+    return new RabbitMqDao(getHost(), getPort(), queue, username, Secret.toString(password), Charset.forName(charset), getVirtualHost());
   }
 
   @Extension

--- a/src/test/resources/rabbitmq.xml
+++ b/src/test/resources/rabbitmq.xml
@@ -5,6 +5,7 @@
     <queue>logstash</queue>
     <username></username>
     <password>{AQAAABAAAAAQ5wlElDfWGri9VuaMh0MCBZWs1fjL31zvnxrkszfW5pA=}</password>
+    <charset>UTF-8</charset>
   </logstashIndexer>
   <dataMigrated>true</dataMigrated>
   <milliSecondTimestamps>true</milliSecondTimestamps>


### PR DESCRIPTION
RabbitMQ stores Charset which is not in the whitelist for XStream and
remoting. So the configuration is not persisted to disk without getting
notified in the UI.
Changing Charset to String is a compatible change with respect to the
persistance.