### PR TITLE
JENKINS-61735 Get all environment variable 

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
@@ -16,14 +16,16 @@ import hudson.model.Run;
 public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serializable
 {
 
+  private hudson.EnvVars envVars;
   private static final Logger LOGGER = Logger.getLogger(LogstashConsoleLogFilter.class.getName());
 
   private transient Run<?, ?> run;
   public LogstashConsoleLogFilter() {}
 
-  public LogstashConsoleLogFilter(Run<?, ?> run)
+  public LogstashConsoleLogFilter(Run<?, ?> run, hudson.EnvVars envVars)
   {
     this.run = run;
+    this.envVars = envVars;
   }
   private static final long serialVersionUID = 1L;
 
@@ -62,7 +64,7 @@ public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serial
 
   LogstashWriter getLogStashWriter(Run<?, ?> build, OutputStream errorStream)
   {
-    return new LogstashWriter(build, errorStream, null, build.getCharset());
+    return new LogstashWriter(build, errorStream, null, build.getCharset(), envVars);
   }
 
   private boolean isLogstashEnabled(Run<?, ?> build)

--- a/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashNotifier.java
@@ -107,7 +107,7 @@ public class LogstashNotifier extends Notifier implements SimpleBuildStep {
 
   // Method to encapsulate calls for unit-testing
   LogstashWriter getLogStashWriter(Run<?, ?> run, OutputStream errorStream, TaskListener listener) {
-    return new LogstashWriter(run, errorStream, listener, run.getCharset());
+    return new LogstashWriter(run, errorStream, listener, run.getCharset(), null);
   }
 
   @Override

--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -61,8 +61,10 @@ public class LogstashWriter {
   private final LogstashIndexerDao dao;
   private boolean connectionBroken;
   private final Charset charset;
+  private final hudson.EnvVars envVars;
 
-  public LogstashWriter(Run<?, ?> run, OutputStream error, TaskListener listener, Charset charset) {
+  public LogstashWriter(Run<?, ?> run, OutputStream error, TaskListener listener, Charset charset, hudson.EnvVars envVars) {
+    this.envVars = envVars;
     this.errorStream = error != null ? error : System.err;
     this.build = run;
     this.listener = listener;
@@ -154,7 +156,7 @@ public class LogstashWriter {
     if (build instanceof AbstractBuild) {
       return new BuildData((AbstractBuild<?, ?>) build, new Date(), listener);
     } else {
-      return new BuildData(build, new Date(), listener);
+      return new BuildData(build, new Date(), listener, envVars);
     }
   }
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -212,21 +212,14 @@ public class BuildData {
   }
 
   // Pipeline project build
-  public BuildData(Run<?, ?> build, Date currentTime, TaskListener listener) {
+  public BuildData(Run<?, ?> build, Date currentTime, TaskListener listener, hudson.EnvVars envVars) {
     initData(build, currentTime);
 
+    buildVariables = envVars;
     rootProjectName = projectName;
     rootFullProjectName = fullProjectName;
     rootProjectDisplayName = displayName;
     rootBuildNum = buildNum;
-
-    try {
-      // TODO: sensitive variables are not filtered, c.f. https://stackoverflow.com/questions/30916085
-      buildVariables = build.getEnvironment(listener);
-    } catch (IOException | InterruptedException e) {
-      LOGGER.log(WARNING,"Unable to get environment for " + build.getDisplayName(),e);
-      buildVariables = new HashMap<>();
-    }
   }
 
   private void initData(Run<?, ?> build, Date currentTime) {

--- a/src/main/java/jenkins/plugins/logstash/pipeline/LogstashSendStep.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/LogstashSendStep.java
@@ -73,7 +73,7 @@ public class LogstashSendStep extends Step
       Run<?, ?> run = getContext().get(Run.class);
       TaskListener listener = getContext().get(TaskListener.class);
       PrintStream errorStream = listener.getLogger();
-      LogstashWriter logstash = new LogstashWriter(run, errorStream, listener, run.getCharset());
+      LogstashWriter logstash = new LogstashWriter(run, errorStream, listener, run.getCharset(), null);
       logstash.writeBuildLog(maxLines);
       if (failBuild && logstash.isConnectionBroken())
       {

--- a/src/main/java/jenkins/plugins/logstash/pipeline/LogstashStep.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/LogstashStep.java
@@ -59,6 +59,7 @@ public class LogstashStep extends Step {
       context
           .newBodyInvoker()
           .withContext(createConsoleLogFilter(context))
+          .withContext(context.get(hudson.EnvVars.class))
           .withCallback(BodyExecutionCallback.wrap(context))
           .start();
       return false;
@@ -68,7 +69,8 @@ public class LogstashStep extends Step {
         throws IOException, InterruptedException {
       ConsoleLogFilter original = context.get(ConsoleLogFilter.class);
       Run<?, ?> build = context.get(Run.class);
-      ConsoleLogFilter subsequent = new LogstashConsoleLogFilter(build);
+      hudson.EnvVars envVars = context.get(hudson.EnvVars.class);
+      ConsoleLogFilter subsequent = new LogstashConsoleLogFilter(build, envVars);
       return BodyInvoker.mergeConsoleLogFilters(original, subsequent);
     }
 

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -58,7 +58,7 @@ public class LogstashWriterTest {
                                              final String url,
                                              final LogstashIndexerDao indexer,
                                              final BuildData data) {
-    return new LogstashWriter(testBuild, error, null, testBuild.getCharset()) {
+    return new LogstashWriter(testBuild, error, null, testBuild.getCharset(), null) {
       @Override
       LogstashIndexerDao getIndexerDao() {
         return indexer;


### PR DESCRIPTION
For declarative pipeline with stages that run in parallel, the logs of console are mixed meaning that it is impossible to extract the log of a dedicated stage.

It is now possible thanks to the STAGE_NAME environment parameter to extract the console logs of a dedicated stage of a declarative pipeline.

To do that, I've recovered the whole set of environment parameters with the command: 
hudson.EnvVars envVars = context.get(hudson.EnvVars.class);

This is introduced into LogstashStep.java and propagated to BuildData.java

Moreover, the NODE_NAME is now part of the environment parameters, so it can be possible to make some filter (e.g. I use Graylog) to make some correlation between an error found in logs and the node that was actually running the stage.