### PR TITLE
JENKINS-59110: enable logging globally for pipeline jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,19 +140,19 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.13.0</version>
+      <version>2.25.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.0-beta.5</version>
+      <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.0-beta.5</version>
+      <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,15 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-stage-step</artifactId>
+      <version>2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <scope>test</scope>
@@ -191,7 +200,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -201,11 +209,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-durable-task-step</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,10 @@
       <artifactId>workflow-durable-task-step</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <scope>test</scope>
@@ -196,10 +200,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConsoleLogFilter.java
@@ -18,13 +18,8 @@ public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serial
 
   private static final Logger LOGGER = Logger.getLogger(LogstashConsoleLogFilter.class.getName());
 
-  private transient Run<?, ?> run;
   public LogstashConsoleLogFilter() {}
 
-  public LogstashConsoleLogFilter(Run<?, ?> run)
-  {
-    this.run = run;
-  }
   private static final long serialVersionUID = 1L;
 
   @Override
@@ -49,15 +44,7 @@ public class LogstashConsoleLogFilter extends ConsoleLogFilter implements Serial
         return logger;
       }
     }
-    if (run != null)
-    {
-      LogstashWriter logstash = getLogStashWriter(run, logger);
-      return new LogstashOutputStream(logger, logstash);
-    }
-    else
-    {
-      return logger;
-    }
+    return logger;
   }
 
   LogstashWriter getLogStashWriter(Run<?, ?> build, OutputStream errorStream)

--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -64,9 +64,17 @@ public class LogstashWriter implements Serializable {
   private final LogstashIndexerDao dao;
   private boolean connectionBroken;
   private final String charset;
+  private final String stageName;
+  private final String agentName;
 
   public LogstashWriter(Run<?, ?> run, OutputStream error, TaskListener listener, Charset charset) {
+    this(run, error, listener, charset, null, null);
+  }
+
+  public LogstashWriter(Run<?, ?> run, OutputStream error, TaskListener listener, Charset charset, String stageName, String agentName) {
     this.errorStream = error != null ? error : System.err;
+    this.stageName = stageName;
+    this.agentName = agentName;
     this.build = run;
     this.listener = listener;
     this.charset = charset.toString();
@@ -157,7 +165,7 @@ public class LogstashWriter implements Serializable {
     if (build instanceof AbstractBuild) {
       return new BuildData((AbstractBuild<?, ?>) build, new Date(), listener);
     } else {
-      return new BuildData(build, new Date(), listener);
+      return new BuildData(build, new Date(), listener, stageName, agentName);
     }
   }
 

--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -210,8 +210,7 @@ public class LogstashWriter implements Serializable {
   private void logErrorMessage(String msg) {
     try {
       connectionBroken = true;
-      if (errorStream != null)
-      {
+      if (errorStream != null) {
         errorStream.write(msg.getBytes(charset));
         errorStream.flush();
       }

--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -35,6 +35,8 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -52,9 +54,8 @@ import java.util.List;
  * @author Liam Newman
  * @since 1.0.5
  */
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class LogstashWriter implements Serializable {
-
-  private static final long serialVersionUID = 1L;
 
   private final OutputStream errorStream;
   private final transient Run<?, ?> build;

--- a/src/main/java/jenkins/plugins/logstash/configuration/ElasticSearch.java
+++ b/src/main/java/jenkins/plugins/logstash/configuration/ElasticSearch.java
@@ -8,6 +8,8 @@ import java.net.URL;
 
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
+import javax.annotation.Nonnull;
+
 import java.security.cert.CertificateException;
 
 import org.apache.commons.lang.StringUtils;
@@ -132,7 +134,7 @@ public class ElasticSearch extends LogstashIndexer<ElasticSearchDao>
     if (getClass() != obj.getClass())
       return false;
     ElasticSearch other = (ElasticSearch) obj;
-    if (!Secret.toString(password).equals(other.getPassword().getPlainText()))
+    if (!Secret.toString(password).equals(Secret.toString(other.getPassword())))
     {
       return false;
     }
@@ -188,35 +190,27 @@ public class ElasticSearch extends LogstashIndexer<ElasticSearchDao>
     ElasticSearchDao esDao = new ElasticSearchDao(getUri(), username, Secret.toString(password));
 
     esDao.setMimeType(getMimeType());
-    try {
-        esDao.setCustomKeyStore(getCustomKeyStore());
-    } catch (KeyStoreException | CertificateException |
-             NoSuchAlgorithmException | KeyManagementException | IOException e) {
-          LOGGER.log(Level.WARNING, e.getMessage(), e);
-    }
-    return esDao;
-  }
-
-  private KeyStore getCustomKeyStore() {
-    KeyStore customKeyStore = null;
-
-    // Fetch custom alias+certificate as a keystore (if present)
     if (!StringUtils.isBlank(customServerCertificateId)) {
-      StandardCertificateCredentials certificateCredentials = getCredentials(customServerCertificateId);
-      if (certificateCredentials != null) {
-        // Fetch keystore containing custom certificate
-        customKeyStore = certificateCredentials.getKeyStore();
+      try {
+          StandardCertificateCredentials certificateCredentials = getCredentials(customServerCertificateId);
+          if (certificateCredentials != null)
+          {
+            esDao.setCustomKeyStore(certificateCredentials.getKeyStore(),
+                Secret.toString(certificateCredentials.getPassword()));
+          }
+      } catch (KeyStoreException | CertificateException |
+               NoSuchAlgorithmException | IOException e) {
+            LOGGER.log(Level.WARNING, e.getMessage(), e);
       }
     }
-
-    return customKeyStore;
+    return esDao;
   }
 
   private StandardCertificateCredentials getCredentials(String credentials)
   {
     return (StandardCertificateCredentials) CredentialsMatchers.firstOrNull(
-        CredentialsProvider.lookupCredentials(StandardCredentials.class,
-            Jenkins.getInstance(), ACL.SYSTEM, Collections.emptyList()),
+        CredentialsProvider.lookupCredentials(StandardCertificateCredentials.class,
+            Jenkins.get(), ACL.SYSTEM, Collections.emptyList()),
         CredentialsMatchers.withId(credentials)
     );
   }
@@ -247,7 +241,7 @@ public class ElasticSearch extends LogstashIndexer<ElasticSearchDao>
                   CredentialsMatchers.instanceOf(StandardCertificateCredentials.class)
               ),
               CredentialsProvider.lookupCredentials(StandardCredentials.class,
-                  Jenkins.getInstance(),
+                  Jenkins.get(),
                   ACL.SYSTEM,
                   Collections.emptyList()
               )

--- a/src/main/java/jenkins/plugins/logstash/configuration/ElasticSearch.java
+++ b/src/main/java/jenkins/plugins/logstash/configuration/ElasticSearch.java
@@ -193,8 +193,7 @@ public class ElasticSearch extends LogstashIndexer<ElasticSearchDao>
     if (!StringUtils.isBlank(customServerCertificateId)) {
       try {
           StandardCertificateCredentials certificateCredentials = getCredentials(customServerCertificateId);
-          if (certificateCredentials != null)
-          {
+          if (certificateCredentials != null) {
             esDao.setCustomKeyStore(certificateCredentials.getKeyStore(),
                 Secret.toString(certificateCredentials.getPassword()));
           }

--- a/src/main/java/jenkins/plugins/logstash/configuration/RabbitMq.java
+++ b/src/main/java/jenkins/plugins/logstash/configuration/RabbitMq.java
@@ -125,7 +125,7 @@ public class RabbitMq extends HostBasedLogstashIndexer<RabbitMqDao>
     if (getClass() != obj.getClass())
       return false;
     RabbitMq other = (RabbitMq) obj;
-    if (!Secret.toString(password).equals(other.getPassword().getPlainText()))
+    if (!Secret.toString(password).equals(Secret.toString(other.getPassword())))
     {
       return false;
     }

--- a/src/main/java/jenkins/plugins/logstash/configuration/Redis.java
+++ b/src/main/java/jenkins/plugins/logstash/configuration/Redis.java
@@ -55,7 +55,7 @@ public class Redis extends HostBasedLogstashIndexer<RedisDao>
     if (getClass() != obj.getClass())
       return false;
     Redis other = (Redis) obj;
-    if (!Secret.toString(password).equals(other.getPassword().getPlainText()))
+    if (!Secret.toString(password).equals(Secret.toString(other.getPassword())))
     {
       return false;
     }

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.logstash.persistence;
 
+import java.io.Serializable;
 import java.util.Calendar;
 import java.util.List;
 
@@ -36,7 +37,9 @@ import net.sf.json.JSONObject;
  * @author Rusty Gerard
  * @since 1.0.0
  */
-public abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao {
+public abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   @Override
   public JSONObject buildPayload(BuildData buildData, String jenkinsUrl, List<String> logLines) {

--- a/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDao.java
@@ -39,8 +39,6 @@ import net.sf.json.JSONObject;
  */
 public abstract class AbstractLogstashIndexerDao implements LogstashIndexerDao, Serializable {
 
-  private static final long serialVersionUID = 1L;
-
   @Override
   public JSONObject buildPayload(BuildData buildData, String jenkinsUrl, List<String> logLines) {
     JSONObject payload = new JSONObject();

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -57,25 +57,25 @@ import org.apache.commons.lang.StringUtils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * POJO for mapping build info to JSON.
  *
  * @author Rusty Gerard
  * @since 1.0.0
  */
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class BuildData implements Serializable {
-  private static final long serialVersionUID = 1L;
 
   // ISO 8601 date format
   private final static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getCanonicalName());
   public static class TestData implements Serializable {
-    private static final long serialVersionUID = 1L;
     private final int totalCount, skipCount, failCount, passCount;
     private final List<FailedTest> failedTestsWithErrorDetail;
     private final List<String> failedTests;
 
     public static class FailedTest implements Serializable {
-      private static final long serialVersionUID = 1L;
       private final String fullName, errorDetails;
       public FailedTest(String fullName, String errorDetails) {
         super();

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -165,6 +165,8 @@ public class BuildData implements Serializable {
   private String url;
   private String buildHost;
   private String buildLabel;
+  private String stageName;
+  private String agentName;
   private int buildNum;
   private long buildDuration;
   private transient String timestamp; // This belongs in the root object
@@ -217,9 +219,11 @@ public class BuildData implements Serializable {
   }
 
   // Pipeline project build
-  public BuildData(Run<?, ?> build, Date currentTime, TaskListener listener) {
+  public BuildData(Run<?, ?> build, Date currentTime, TaskListener listener, String stageName, String agentName) {
     initData(build, currentTime);
 
+    this.agentName = agentName;
+    this.stageName = stageName;
     rootProjectName = projectName;
     rootFullProjectName = fullProjectName;
     rootProjectDisplayName = displayName;
@@ -448,5 +452,21 @@ public class BuildData implements Serializable {
 
   public void setTestResults(TestData testResults) {
     this.testResults = testResults;
+  }
+
+  public String getStageName() {
+    return stageName;
+  }
+
+  public void setStageName(String stageName) {
+    this.stageName = stageName;
+  }
+
+  public String getAgentName() {
+    return agentName;
+  }
+
+  public void setAgentName(String agentName) {
+    this.agentName = agentName;
   }
 }

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -268,8 +268,7 @@ public class BuildData implements Serializable {
   public void updateResult()
   {
     if (build != null) {
-      if (result == null && build.getResult() != null)
-      {
+      if (result == null && build.getResult() != null) {
         Result result = build.getResult();
         this.result = result == null ? null : result.toString();
       }

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -48,6 +48,7 @@ import java.util.logging.Logger;
 
 import static java.util.logging.Level.WARNING;
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import net.sf.json.JSONObject;
 
@@ -62,15 +63,19 @@ import com.google.gson.GsonBuilder;
  * @author Rusty Gerard
  * @since 1.0.0
  */
-public class BuildData {
+public class BuildData implements Serializable {
+  private static final long serialVersionUID = 1L;
+
   // ISO 8601 date format
   private final static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getCanonicalName());
-  public static class TestData {
+  public static class TestData implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final int totalCount, skipCount, failCount, passCount;
     private final List<FailedTest> failedTestsWithErrorDetail;
     private final List<String> failedTests;
 
-    public static class FailedTest {
+    public static class FailedTest implements Serializable {
+      private static final long serialVersionUID = 1L;
       private final String fullName, errorDetails;
       public FailedTest(String fullName, String errorDetails) {
         super();
@@ -262,14 +267,16 @@ public class BuildData {
 
   public void updateResult()
   {
-    if (result == null && build.getResult() != null)
-    {
-      Result result = build.getResult();
-      this.result = result == null ? null : result.toString();
-    }
-    Action testResultAction = build.getAction(AbstractTestResultAction.class);
-    if (testResults == null && testResultAction != null) {
-      testResults = new TestData(testResultAction);
+    if (build != null) {
+      if (result == null && build.getResult() != null)
+      {
+        Result result = build.getResult();
+        this.result = result == null ? null : result.toString();
+      }
+      Action testResultAction = build.getAction(AbstractTestResultAction.class);
+      if (testResults == null && testResultAction != null) {
+        testResults = new TestData(testResultAction);
+      }
     }
   }
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
@@ -113,7 +113,7 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
     clientBuilder = factory;
   }
 
-  private void getClientBuilder() throws IOException {
+  private synchronized void getClientBuilder() throws IOException {
     if (clientBuilder == null) {
       clientBuilder = HttpClientBuilder.create();
       if (keystoreBytes != null) {

--- a/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
@@ -113,21 +113,16 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
     clientBuilder = factory;
   }
 
-  private void getClientBuilder() throws IOException
-  {
+  private void getClientBuilder() throws IOException {
     if (clientBuilder == null) {
       clientBuilder = HttpClientBuilder.create();
-      if (keystoreBytes != null)
-      {
+      if (keystoreBytes != null) {
         KeyStore trustStore;
-        try
-        {
+        try {
           trustStore = KeyStore.getInstance("PKCS12");
           trustStore.load(new ByteArrayInputStream(keystoreBytes), keyStorePassword.toCharArray());
           SSLHelper.setClientBuilderSSLContext(clientBuilder, trustStore);
-        }
-        catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | KeyManagementException e)
-        {
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | KeyManagementException e) {
           throw new IOException(e);
         }
       }
@@ -183,8 +178,7 @@ public class ElasticSearchDao extends AbstractLogstashIndexerDao {
   }
 
   public void setCustomKeyStore(KeyStore customKeyStore, String keyStorePassword) throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
-    if (customKeyStore != null)
-    {
+    if (customKeyStore != null) {
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       customKeyStore.store(bos, keyStorePassword.toCharArray());
       keystoreBytes = bos.toByteArray();

--- a/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/ElasticSearchDao.java
@@ -53,6 +53,7 @@ import java.security.cert.CertificateException;
 
 import com.google.common.collect.Range;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.plugins.logstash.utils.SSLHelper;
 
 
@@ -62,9 +63,8 @@ import jenkins.plugins.logstash.utils.SSLHelper;
  * @author Liam Newman
  * @since 1.0.4
  */
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class ElasticSearchDao extends AbstractLogstashIndexerDao {
-
-  private static final long serialVersionUID = 1L;
 
   private transient HttpClientBuilder clientBuilder;
   private final URI uri;

--- a/src/main/java/jenkins/plugins/logstash/persistence/HostBasedLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/HostBasedLogstashIndexerDao.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.StringUtils;
  * @since 2.0.0
  */
 public abstract class HostBasedLogstashIndexerDao extends AbstractLogstashIndexerDao {
+  private static final long serialVersionUID = 1L;
   private final String host;
   private final int port;
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/HostBasedLogstashIndexerDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/HostBasedLogstashIndexerDao.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang.StringUtils;
  * @since 2.0.0
  */
 public abstract class HostBasedLogstashIndexerDao extends AbstractLogstashIndexerDao {
-  private static final long serialVersionUID = 1L;
+
   private final String host;
   private final int port;
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashDao.java
@@ -7,8 +7,6 @@ import java.nio.charset.StandardCharsets;
 
 public class LogstashDao extends HostBasedLogstashIndexerDao {
 
-  private static final long serialVersionUID = 1L;
-
   public LogstashDao(String logstashHostString, int logstashPortInt) {
     super(logstashHostString, logstashPortInt);
   }

--- a/src/main/java/jenkins/plugins/logstash/persistence/LogstashDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/LogstashDao.java
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets;
 
 public class LogstashDao extends HostBasedLogstashIndexerDao {
 
+  private static final long serialVersionUID = 1L;
+
   public LogstashDao(String logstashHostString, int logstashPortInt) {
     super(logstashHostString, logstashPortInt);
   }

--- a/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
@@ -85,7 +85,7 @@ public class RabbitMqDao extends HostBasedLogstashIndexerDao {
     initPool();
   }
 
-  private void getPool() {
+  private synchronized void getPool() {
     if (pool == null) {
       pool = new ConnectionFactory();
       initPool();

--- a/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
@@ -85,11 +85,12 @@ public class RabbitMqDao extends HostBasedLogstashIndexerDao {
     initPool();
   }
 
-  private synchronized void getPool() {
+  private synchronized ConnectionFactory getPool() {
     if (pool == null) {
       pool = new ConnectionFactory();
       initPool();
     }
+    return pool;
   }
 
   private void initPool() {
@@ -142,8 +143,7 @@ public class RabbitMqDao extends HostBasedLogstashIndexerDao {
     Connection connection = null;
     Channel channel = null;
     try {
-      getPool();
-      connection = pool.newConnection();
+      connection = getPool().newConnection();
       channel = connection.createChannel();
       // Ensure the queue exists
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
@@ -33,6 +33,8 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * RabbitMQ Data Access Object.
  *
@@ -42,9 +44,8 @@ import com.rabbitmq.client.ConnectionFactory;
  * @author Rusty Gerard
  * @since 1.0.0
  */
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class RabbitMqDao extends HostBasedLogstashIndexerDao {
-
-  private static final long serialVersionUID = 1L;
 
   private transient ConnectionFactory pool;
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RabbitMqDao.java
@@ -85,22 +85,19 @@ public class RabbitMqDao extends HostBasedLogstashIndexerDao {
     initPool();
   }
 
-  private void getPool()
-  {
+  private void getPool() {
     if (pool == null) {
       pool = new ConnectionFactory();
       initPool();
     }
   }
 
-  private void initPool()
-  {
+  private void initPool() {
     if (pool != null)
     {
       pool.setHost(getHost());
       pool.setPort(getPort());
-      if (virtualHost != null)
-      {
+      if (virtualHost != null) {
         pool.setVirtualHost(virtualHost);
       }
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
@@ -74,7 +74,7 @@ public class RedisDao extends HostBasedLogstashIndexerDao {
     pool = factory;
   }
 
-  private void getJedisPool() {
+  private synchronized void getJedisPool() {
     if (pool == null) {
       pool = new JedisPool(new JedisPoolConfig(), getHost(), getPort());
     }

--- a/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
@@ -41,7 +41,10 @@ import redis.clients.jedis.exceptions.JedisException;
  * @since 1.0.0
  */
 public class RedisDao extends HostBasedLogstashIndexerDao {
-  private final JedisPool pool;
+
+  private static final long serialVersionUID = 1L;
+
+  private transient JedisPool pool;
 
   private final String password;
   private final String key;
@@ -68,7 +71,15 @@ public class RedisDao extends HostBasedLogstashIndexerDao {
 
     // The JedisPool must be a singleton
     // We assume this is used as a singleton as well
-    pool = factory == null ? new JedisPool(new JedisPoolConfig(), host, port) : factory;
+    pool = factory;
+  }
+
+  private void getJedisPool()
+  {
+    if (pool == null)
+    {
+      pool = new JedisPool(new JedisPoolConfig(), getHost(), getPort());
+    }
   }
 
   public String getPassword()
@@ -86,6 +97,7 @@ public class RedisDao extends HostBasedLogstashIndexerDao {
     Jedis jedis = null;
     boolean connectionBroken = false;
     try {
+      getJedisPool();
       jedis = pool.getResource();
       if (!StringUtils.isBlank(password)) {
         jedis.auth(password);

--- a/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
@@ -74,10 +74,8 @@ public class RedisDao extends HostBasedLogstashIndexerDao {
     pool = factory;
   }
 
-  private void getJedisPool()
-  {
-    if (pool == null)
-    {
+  private void getJedisPool() {
+    if (pool == null) {
       pool = new JedisPool(new JedisPoolConfig(), getHost(), getPort());
     }
   }

--- a/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
@@ -40,9 +41,8 @@ import redis.clients.jedis.exceptions.JedisException;
  * @author Rusty Gerard
  * @since 1.0.0
  */
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class RedisDao extends HostBasedLogstashIndexerDao {
-
-  private static final long serialVersionUID = 1L;
 
   private transient JedisPool pool;
 

--- a/src/main/java/jenkins/plugins/logstash/persistence/SyslogDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/SyslogDao.java
@@ -40,7 +40,7 @@ public class SyslogDao extends HostBasedLogstashIndexerDao {
     return messageFormat;
   }
 
-  private void getMessageSender() {
+  private synchronized void getMessageSender() {
     if (messageSender == null) {
       messageSender = new UdpSyslogMessageSender();
     }

--- a/src/main/java/jenkins/plugins/logstash/persistence/SyslogDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/SyslogDao.java
@@ -40,10 +40,8 @@ public class SyslogDao extends HostBasedLogstashIndexerDao {
     return messageFormat;
   }
 
-  private void getMessageSender()
-  {
-    if (messageSender == null)
-    {
+  private void getMessageSender() {
+    if (messageSender == null) {
       messageSender = new UdpSyslogMessageSender();
     }
   }

--- a/src/main/java/jenkins/plugins/logstash/persistence/SyslogDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/SyslogDao.java
@@ -7,12 +7,13 @@ import com.cloudbees.syslog.MessageFormat;
 import com.cloudbees.syslog.Severity;
 import com.cloudbees.syslog.sender.UdpSyslogMessageSender;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /*
  * TODO: add support for TcpSyslogMessageSender
  */
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class SyslogDao extends HostBasedLogstashIndexerDao {
-
-  private static final long serialVersionUID = 1L;
 
   private MessageFormat messageFormat = MessageFormat.RFC_3164;
   private transient UdpSyslogMessageSender messageSender;

--- a/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
@@ -1,0 +1,63 @@
+package jenkins.plugins.logstash.pipeline;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
+
+import hudson.Extension;
+import hudson.model.Queue;
+import hudson.model.Run;
+import jenkins.plugins.logstash.LogstashConfiguration;
+import jenkins.plugins.logstash.LogstashOutputStream;
+import jenkins.plugins.logstash.LogstashWriter;
+
+public class GlobalDecorator extends TaskListenerDecorator
+{
+  private static final Logger LOGGER = Logger.getLogger(GlobalDecorator.class.getName());
+
+  private static final long serialVersionUID = 1L;
+
+  private transient Run<?, ?> run;
+
+  public GlobalDecorator(Run<?, ?> run)
+  {
+    LOGGER.log(Level.INFO, "Creating decorator for {0}", run.toString());
+    this.run = run;
+  }
+
+  @Override
+  public OutputStream decorate(OutputStream logger) throws IOException, InterruptedException
+  {
+    LogstashWriter writer = new LogstashWriter(run, logger, null, StandardCharsets.UTF_8);
+    LogstashOutputStream out = new LogstashOutputStream(logger, writer);
+    return out;
+  }
+
+  @Extension
+  public static final class Factory implements TaskListenerDecorator.Factory {
+
+      @Override
+      public TaskListenerDecorator of(FlowExecutionOwner owner)
+      {
+        if (!LogstashConfiguration.getInstance().isEnableGlobally())
+        {
+          return null;
+        }
+        try {
+          Queue.Executable executable = owner.getExecutable();
+          if (executable instanceof Run) { // we need at least getStartTimeInMillis
+              return new GlobalDecorator((Run<?, ?>) executable);
+          }
+      } catch (IOException x) {
+          LOGGER.log(Level.WARNING, null, x);
+      }
+      return null;      }
+  }
+
+
+}

--- a/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
@@ -10,6 +10,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Queue;
 import hudson.model.Run;
@@ -17,10 +18,9 @@ import jenkins.plugins.logstash.LogstashConfiguration;
 import jenkins.plugins.logstash.LogstashOutputStream;
 import jenkins.plugins.logstash.LogstashWriter;
 
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class GlobalDecorator extends TaskListenerDecorator {
   private static final Logger LOGGER = Logger.getLogger(GlobalDecorator.class.getName());
-
-  private static final long serialVersionUID = 1L;
 
   private transient Run<?, ?> run;
   private String stageName;

--- a/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
@@ -16,48 +16,42 @@ import jenkins.plugins.logstash.LogstashConfiguration;
 import jenkins.plugins.logstash.LogstashOutputStream;
 import jenkins.plugins.logstash.LogstashWriter;
 
-public class GlobalDecorator extends TaskListenerDecorator
-{
-  private static final Logger LOGGER = Logger.getLogger(GlobalDecorator.class.getName());
+public class GlobalDecorator extends TaskListenerDecorator {
+    private static final Logger LOGGER = Logger.getLogger(GlobalDecorator.class.getName());
 
-  private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-  private transient Run<?, ?> run;
+    private transient Run<?, ?> run;
 
-  public GlobalDecorator(Run<?, ?> run)
-  {
-    LOGGER.log(Level.INFO, "Creating decorator for {0}", run.toString());
-    this.run = run;
-  }
+    public GlobalDecorator(Run<?, ?> run) {
+	LOGGER.log(Level.INFO, "Creating decorator for {0}", run.toString());
+	this.run = run;
+    }
 
-  @Override
-  public OutputStream decorate(OutputStream logger) throws IOException, InterruptedException
-  {
-    LogstashWriter writer = new LogstashWriter(run, logger, null, StandardCharsets.UTF_8);
-    LogstashOutputStream out = new LogstashOutputStream(logger, writer);
-    return out;
-  }
+    @Override
+    public OutputStream decorate(OutputStream logger) throws IOException, InterruptedException {
+	LogstashWriter writer = new LogstashWriter(run, logger, null, StandardCharsets.UTF_8);
+	LogstashOutputStream out = new LogstashOutputStream(logger, writer);
+	return out;
+    }
 
-  @Extension
-  public static final class Factory implements TaskListenerDecorator.Factory {
+    @Extension
+    public static final class Factory implements TaskListenerDecorator.Factory {
 
-      @Override
-      public TaskListenerDecorator of(FlowExecutionOwner owner)
-      {
-        if (!LogstashConfiguration.getInstance().isEnableGlobally())
-        {
-          return null;
-        }
-        try {
-          Queue.Executable executable = owner.getExecutable();
-          if (executable instanceof Run) { // we need at least getStartTimeInMillis
-              return new GlobalDecorator((Run<?, ?>) executable);
-          }
-      } catch (IOException x) {
-          LOGGER.log(Level.WARNING, null, x);
-      }
-      return null;      }
-  }
-
-
+	@Override
+	public TaskListenerDecorator of(FlowExecutionOwner owner) {
+	    if (!LogstashConfiguration.getInstance().isEnableGlobally()) {
+		return null;
+	    }
+	    try {
+		Queue.Executable executable = owner.getExecutable();
+		if (executable instanceof Run) { // we need at least getStartTimeInMillis
+		    return new GlobalDecorator((Run<?, ?>) executable);
+		}
+	    } catch (IOException x) {
+		LOGGER.log(Level.WARNING, null, x);
+	    }
+	    return null;
+	}
+    }
 }

--- a/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
@@ -26,10 +26,10 @@ public class GlobalDecorator extends TaskListenerDecorator {
   private String stageName;
   private String agentName;
 
-  public GlobalDecorator(Run<?, ?> run) {
+  public GlobalDecorator(WorkflowRun run) {
     this(run, null, null);
   }
-  public GlobalDecorator(Run<?, ?> run, String stageName, String agentName) {
+  public GlobalDecorator(WorkflowRun run, String stageName, String agentName) {
     LOGGER.log(Level.INFO, "Creating decorator for {0}", run.toString());
     this.run = run;
     this.stageName = stageName;
@@ -54,7 +54,7 @@ public class GlobalDecorator extends TaskListenerDecorator {
       try {
         Queue.Executable executable = owner.getExecutable();
         if (executable instanceof WorkflowRun) {
-          return new GlobalDecorator((Run<?, ?>) executable);
+          return new GlobalDecorator((WorkflowRun) executable);
         }
       } catch (IOException x) {
         LOGGER.log(Level.WARNING, null, x);

--- a/src/main/java/jenkins/plugins/logstash/pipeline/LogstashStep.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/LogstashStep.java
@@ -64,8 +64,7 @@ public class LogstashStep extends Step {
     public boolean start() throws Exception {
       StepContext context = getContext();
       BodyInvoker invoker = context.newBodyInvoker().withCallback(BodyExecutionCallback.wrap(context));
-      if (LogstashConfiguration.getInstance().isEnableGlobally())
-      {
+      if (LogstashConfiguration.getInstance().isEnableGlobally()) {
         context.get(TaskListener.class).getLogger().println("The logstash step is unnecessary when logstash is enabled for all builds.");
       } else {
             invoker.withContext(getMergedDecorator(context));
@@ -110,8 +109,7 @@ public class LogstashStep extends Step {
     }
 
     @Override
-    public Set<? extends Class<?>> getRequiredContext()
-    {
+    public Set<? extends Class<?>> getRequiredContext() {
       return ImmutableSet.of(Run.class);
     }
   }

--- a/src/main/java/jenkins/plugins/logstash/pipeline/LogstashStep.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/LogstashStep.java
@@ -13,6 +13,7 @@ import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.StepNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
@@ -92,7 +93,7 @@ public class LogstashStep extends Step {
         }
       }
       String agentName = getAgentName(node);
-      return TaskListenerDecorator.merge(context.get(TaskListenerDecorator.class), new GlobalDecorator(run, stageName, agentName));
+      return TaskListenerDecorator.merge(context.get(TaskListenerDecorator.class), new GlobalDecorator((WorkflowRun) run, stageName, agentName));
     }
 
     private String getAgentName(FlowNode node) {

--- a/src/main/java/jenkins/plugins/logstash/pipeline/LogstashStep.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/LogstashStep.java
@@ -8,7 +8,11 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graph.StepNode;
 import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
@@ -17,6 +21,8 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.support.steps.ExecutorStep;
+import org.jenkinsci.plugins.workflow.support.steps.StageStep;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.google.common.collect.ImmutableSet;
@@ -76,7 +82,56 @@ public class LogstashStep extends Step {
     private TaskListenerDecorator getMergedDecorator(StepContext context)
         throws IOException, InterruptedException {
       Run<?, ?> run = context.get(Run.class);
-      return TaskListenerDecorator.merge(context.get(TaskListenerDecorator.class), new GlobalDecorator(run));
+      FlowNode node = context.get(FlowNode.class);
+      FlowNode stageNode = getStageNode(node);
+      String stageName = null;
+      if (stageNode != null) {
+        LabelAction labelAction = stageNode.getAction(LabelAction.class);
+        if (labelAction != null) {
+            stageName = labelAction.getDisplayName();
+        }
+      }
+      String agentName = getAgentName(node);
+      return TaskListenerDecorator.merge(context.get(TaskListenerDecorator.class), new GlobalDecorator(run, stageName, agentName));
+    }
+
+    private String getAgentName(FlowNode node) {
+      for (BlockStartNode bsn : node.iterateEnclosingBlocks()) {
+          if (bsn instanceof StepNode) {
+              StepDescriptor descriptor = ((StepNode) bsn).getDescriptor();
+              if (descriptor instanceof ExecutorStep.DescriptorImpl) {
+                  WorkspaceAction workspaceAction = bsn.getAction(WorkspaceAction.class);
+                  if (workspaceAction != null) {
+                      return workspaceAction.getNode();
+                  }
+              }
+          }
+      }
+
+      return null;
+  }
+
+    private FlowNode getStageNode(FlowNode node) {
+      for (BlockStartNode bsn : node.iterateEnclosingBlocks()) {
+        if (isStageNode(bsn)) {
+          return bsn;
+        }
+      }
+      return null;
+    }
+
+    private boolean isStageNode(FlowNode node) {
+        if (node instanceof StepNode) {
+            StepDescriptor descriptor = ((StepNode) node).getDescriptor();
+            if (descriptor instanceof StageStep.DescriptorImpl) {
+                LabelAction labelAction = node.getAction(LabelAction.class);
+                if (labelAction != null) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /** {@inheritDoc} */
@@ -110,7 +165,7 @@ public class LogstashStep extends Step {
 
     @Override
     public Set<? extends Class<?>> getRequiredContext() {
-      return ImmutableSet.of(Run.class);
+      return ImmutableSet.of(Run.class, FlowNode.class);
     }
   }
 

--- a/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashOutputStreamTest.java
@@ -1,8 +1,8 @@
 package jenkins.plugins.logstash;
 
 import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;
@@ -33,7 +33,7 @@ public class LogstashOutputStreamTest {
     buffer = new ByteArrayOutputStream();
     Mockito.doNothing().when(mockWriter).write(anyString());
     when(mockWriter.isConnectionBroken()).thenReturn(false);
-    when(mockWriter.getCharset()).thenReturn(Charset.defaultCharset());
+    when(mockWriter.getCharset()).thenReturn(Charset.defaultCharset().toString());
   }
 
   @After

--- a/src/test/java/jenkins/plugins/logstash/PipelineTest.java
+++ b/src/test/java/jenkins/plugins/logstash/PipelineTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import hudson.model.Slave;
 import jenkins.plugins.logstash.configuration.MemoryIndexer;
 import jenkins.plugins.logstash.persistence.MemoryDao;
 import net.sf.json.JSONObject;
@@ -53,6 +54,28 @@ public class PipelineTest
     JSONObject firstLine = dataLines.get(0);
     JSONObject data = firstLine.getJSONObject("data");
     assertThat(data.getString("result"),equalTo("SUCCESS"));
+  }
+
+  @Test
+  public void logstashStageAndAgent() throws Exception
+  {
+    Slave slave = j.createOnlineSlave();
+    String agentName = slave.getNodeName();
+    WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+    p.setDefinition(new CpsFlowDefinition("stage('stage1') { " +
+      "node('" + agentName + "') {\n" +
+      "logstash {\n" +
+        "currentBuild.result = 'SUCCESS'\n" +
+        "echo 'Message'\n" +
+    "}}}", true));
+    j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+    List<JSONObject> dataLines = memoryDao.getOutput();
+    assertThat(dataLines.size(), equalTo(1));
+    JSONObject firstLine = dataLines.get(0);
+    JSONObject data = firstLine.getJSONObject("data");
+    assertThat(data.getString("result"),equalTo("SUCCESS"));
+    assertThat(data.getString("stageName"),equalTo("stage1"));
+    assertThat(data.getString("agentName"),equalTo(agentName));
   }
 
   @Test

--- a/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
@@ -79,7 +79,6 @@ public class AbstractLogstashIndexerDaoTest {
 
   private AbstractLogstashIndexerDao getInstance() {
     return new AbstractLogstashIndexerDao() {
-      private static final long serialVersionUID = 1L;
 
       @Override
     public void push(String data) throws IOException {}

--- a/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/AbstractLogstashIndexerDaoTest.java
@@ -79,6 +79,8 @@ public class AbstractLogstashIndexerDaoTest {
 
   private AbstractLogstashIndexerDao getInstance() {
     return new AbstractLogstashIndexerDao() {
+      private static final long serialVersionUID = 1L;
+
       @Override
     public void push(String data) throws IOException {}
 

--- a/src/test/java/jenkins/plugins/logstash/persistence/ElasticSearchSSLCertsTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/ElasticSearchSSLCertsTest.java
@@ -40,14 +40,11 @@ public class ElasticSearchSSLCertsTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private static final KeyStore NO_CLIENT_KEYSTORE = null;
     private static final SSLContext NO_SSL_CONTEXT = null;
-    private static final TrustManager[] NO_SERVER_TRUST_MANAGER = null;
 
     private static final char[] KEYPASS_AND_STOREPASS_VALUE = "aaaaaa".toCharArray();
     private static final String JAVA_KEYSTORE = "jks";
-    private static final String CLIENT_KEYSTORE = "elasticsearch-sslcerts/keystore.ks";
-    private static final String CLIENT_TRUSTSTORE = "elasticsearch-sslcerts/truststore.ks";
+    private static final String CLIENT_KEYSTORE = "elasticsearch-sslcerts/cert.pkcs12";
 
     @Test
     public void NoSSLPost_NoSSLServer_Returns200OK() throws Exception {
@@ -98,7 +95,7 @@ public class ElasticSearchSSLCertsTest {
 
         ElasticSearchDao dao = new ElasticSearchDao(new URI("https://" + baseUrl), "", "");
         KeyStore keyStore = getStore(CLIENT_KEYSTORE, KEYPASS_AND_STOREPASS_VALUE);
-        dao.setCustomKeyStore(keyStore);
+        dao.setCustomKeyStore(keyStore, "aaaaaa");
 
         try {
             dao.push("");
@@ -116,7 +113,7 @@ public class ElasticSearchSSLCertsTest {
 
         ElasticSearchDao dao = new ElasticSearchDao(new URI("https://" + baseUrl), "", "");
         KeyStore keyStore = getStore(CLIENT_KEYSTORE, KEYPASS_AND_STOREPASS_VALUE);
-        dao.setCustomKeyStore(keyStore);
+        dao.setCustomKeyStore(keyStore, "aaaaaa");
 
         try {
             thrown.expect(IsInstanceOf.instanceOf(SSLException.class));


### PR DESCRIPTION
To be able to log globally for pipeline a TaskListenerDecorator must be
implemented.
Potentially the decorator will be transferred to the agent jvm so
everything must be Serializable (this is not tested).
This also includes getting information about stage/agent if the logstash step is inside a stage/node