### PR TITLE
Docs migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,27 @@ Jenkins Logstash Plugin
 Travis: [![Build Status](https://travis-ci.org/jenkinsci/logstash-plugin.svg?branch=master)](https://travis-ci.org/jenkinsci/logstash-plugin)
 Jenkins: [![Build Status](https://ci.jenkins.io/job/Plugins/job/logstash-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/logstash-plugin/job/master/)
 
-This plugin adds support for sending a job's console log to Logstash indexers such as [Elastic Search](https://www.elastic.co/products/elasticsearch), [Logstash](https://www.elastic.co/de/products/logstash), [RabbitMQ](https://www.rabbitmq.com), [Redis](https://redis.io/) or to Syslog.
+This plugin adds support for sending a job's console log to Logstash indexers such as [Elastic Search](https://www.elastic.co/products/elasticsearch), 
+[Logstash](https://www.elastic.co/de/products/logstash), [RabbitMQ](https://www.rabbitmq.com), 
+[Redis](https://redis.io/) or to Syslog.
 
-* see [Jenkins wiki](https://wiki.jenkins-ci.org/display/JENKINS/Logstash+Plugin) for detailed feature descriptions
-* use [JIRA](https://issues.jenkins-ci.org) to report issues / feature requests
+* use [Jira](https://issues.jenkins.io) to report issues / feature requests
 
 Install
 =======
 
-* Generate the `hpi` file with the command: `mvn package`
-
-* Put the `hpi` file in the directory `$JENKINS_HOME/plugins`
-* Restart jenkins
+* Search for 'Logstash' in your Jenkins plugin manager
 
 Configure
 =========
 
-Currently supported methods of input/output:
+Supported methods of input/output:
 
-* ElasticSearch {REST API}
+* ElasticSearch (REST API)
 * Logstash TCP input
-* Redis {format => 'json_event'}
-* RabbitMQ {mechanism => PLAIN}
-* Syslog {format => cee/json ([RFC-5424](https://tools.ietf.org/html/rfc5424),[RFC-3164](https://tools.ietf.org/html/rfc3164)), protocol => UDP}
+* Redis (format => 'json_event')
+* RabbitMQ (mechanism => PLAIN)
+* Syslog (format => cee/json ([RFC-5424](https://tools.ietf.org/html/rfc5424),[RFC-3164](https://tools.ietf.org/html/rfc3164)), protocol => UDP)
 
 Pipeline
 ========
@@ -44,7 +42,7 @@ Logstash plugin can be used as a publisher in pipeline jobs to send the whole lo
 
 It can be used as a wrapper step to send each log line separately.
 
-Note: when you combine with timestamps step, you should make the timestamps the outer most block. Otherwise you get the timestamps as part of the log lines, basically duplicating the timestamp information.
+Note: when you combine with timestamps step, you should make the timestamps the outermost block. Otherwise you get the timestamps as part of the log lines, basically duplicating the timestamp information.
 
 ```Groovy
 timestamps {
@@ -57,6 +55,98 @@ timestamps {
   }
 }
 ```
+
+Enable Globally
+=======
+
+You can enable this plugin globally in the Jenkins system configuration page, 
+or with the [configuration as code](https://plugins.jenkins.io/configuration-as-code/) plugin: 
+
+```yaml
+unclassified:
+  logstashConfiguration:
+    enableGlobally: true
+    enabled: true
+    logstashIndexer:
+        logstash:
+            host: "localhost"
+            port: 9200
+```
+
+JobProperty
+=======
+
+This component streams individual log lines to the indexer for post-processing, 
+along with any build data that is available at the start (some information such as the build status is unavailable or incomplete).
+
+Post-Build Publisher
+=======
+
+This component pushes the tail of the job's log to the indexer for post-processing, 
+along with all build data at the time the post-build action had started (if any post-build actions are scheduled after this plugin they will not be recorded).
+
+JSON Payload Format
+=======
+
+Example payload sent to the indexer (e.g. RabbitMQ) using the post-build action component. 
+
+_Note 1: when the build wrapper is used, some information such as the build result will be missing or incomplete, 
+and the "message" array will contain a single log line._
+
+_Note 2: `data.testResults` will only be present if a publisher records your test results in the build, 
+for example by using the [JUnit Plugin](https://plugins.jenkins.io/junit/)._
+
+<details>
+
+<summary>Click to expand the JSON payload</summary>
+
+```json
+{
+   "data":{
+      "id":"2014-10-13_19-51-29",
+      "result":"SUCCESS",
+      "projectName":"my_example_job",
+      "fullProjectName":"folder/my_example_job",
+      "displayName":"#1",
+      "fullDisplayName":"My Example Job #1",
+      "url":"job/my_example_job/1/",
+      "buildHost":"Jenkins",
+      "buildLabel":"",
+      "buildNum":1,
+      "buildDuration":0,
+      "rootProjectName":"my_example_job",
+      "rootFullProjectName":"folder/my_example_job",
+	  "rootProjectDisplayName":"#1",
+      "rootBuildNum":1,
+      "buildVariables":{
+         "PARAM1":"VALUE1",
+         "PARAM2":"VALUE2"
+      },
+      "testResults":{
+         "totalCount":45,
+         "skipCount":0,
+         "failCount":0,
+         "failedTests":[]
+      }
+   },
+   "message":[
+      "Started by user anonymous",
+      "Building in workspace /var/lib/jenkins/jobs/my_example_job/workspace",
+      "Hello, World!"
+   ],
+   "source":"jenkins",
+   "source_host":"http://localhost:8080/jenkins/",
+   "@timestamp":"2014-10-13T19:51:29-0700",
+   "@version":1
+}
+```
+
+</details>
+
+Changelog
+=======
+
+See [Changelog](./CHANGELOG.md).
 
 License
 =======

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <name>Logstash</name>
   <description>A Logstash agent to send Jenkins logs to a Logstash indexer.</description>
-  <url>https://wiki.jenkins.io/display/JENKINS/Logstash+Plugin</url>
+  <url>https://github.com/jenkinsci/logstash-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>

--- a/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/help-enableGlobally.html
+++ b/src/main/resources/jenkins/plugins/logstash/LogstashConfiguration/help-enableGlobally.html
@@ -1,1 +1,1 @@
-Checking will make all non pipeline builds forward their log to the above indexer.
+Checking will make all builds forward their log to the above indexer.


### PR DESCRIPTION
https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/#how-to-enable-github-documentation-for-your-plugin

I noticed the plugins documentation on the plugin site didn't look accurate, https://plugins.jenkins.io/logstash/, I see the github docs have moved on but the plugin hasn't been changed to point it's docs to GitHub