### PR TITLE
[JENKINS-65530] Add dbIndex support for Redis.

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/configuration/Redis.java
+++ b/src/main/java/jenkins/plugins/logstash/configuration/Redis.java
@@ -17,6 +17,7 @@ public class Redis extends HostBasedLogstashIndexer<RedisDao>
 
   protected String key;
   protected Secret password;
+  protected int dbindex;
 
   @DataBoundConstructor
   public Redis()
@@ -43,6 +44,17 @@ public class Redis extends HostBasedLogstashIndexer<RedisDao>
   public void setPassword(Secret password)
   {
     this.password = password;
+  }
+
+  public int getDbindex()
+  {
+    return dbindex;
+  }
+
+  @DataBoundSetter
+  public void setDbindex(int dbindex)
+  {
+    this.dbindex = dbindex;
   }
 
   @Override
@@ -85,7 +97,7 @@ public class Redis extends HostBasedLogstashIndexer<RedisDao>
   @Override
   public RedisDao createIndexerInstance()
   {
-    return new RedisDao(getHost(), getPort(), key, Secret.toString(password));
+    return new RedisDao(getHost(), getPort(), key, Secret.toString(password), getDbindex());
   }
 
   @Extension
@@ -103,6 +115,11 @@ public class Redis extends HostBasedLogstashIndexer<RedisDao>
     public int getDefaultPort()
     {
       return 6379;
+    }
+
+    public int getDefaultDbindex()
+    {
+      return 0;
     }
 
     public FormValidation doCheckKey(@QueryParameter("value") String value)

--- a/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/RedisDao.java
@@ -48,10 +48,11 @@ public class RedisDao extends HostBasedLogstashIndexerDao {
 
   private final String password;
   private final String key;
+  private final int dbindex;
 
   //primary constructor used by indexer factory
-  public RedisDao(String host, int port, String key, String password) {
-    this(null, host, port, key, password);
+  public RedisDao(String host, int port, String key, String password, int dbindex) {
+    this(null, host, port, key, password, dbindex);
   }
 
   /*
@@ -59,11 +60,12 @@ public class RedisDao extends HostBasedLogstashIndexerDao {
    *       With Powermock we can intercept the creation of the JedisPool and replace with a mock
    *       making this constructor obsolete
    */
-  RedisDao(JedisPool factory, String host, int port, String key, String password) {
+  RedisDao(JedisPool factory, String host, int port, String key, String password, int dbindex) {
     super(host, port);
 
     this.key = key;
     this.password = password;
+    this.dbindex = dbindex;
 
     if (StringUtils.isBlank(key)) {
       throw new IllegalArgumentException("redis key is required");
@@ -90,6 +92,11 @@ public class RedisDao extends HostBasedLogstashIndexerDao {
     return key;
   }
 
+  public int getDbindex()
+  {
+    return dbindex;
+  }
+
   @Override
   public void push(String data) throws IOException {
     Jedis jedis = null;
@@ -99,6 +106,9 @@ public class RedisDao extends HostBasedLogstashIndexerDao {
       jedis = pool.getResource();
       if (!StringUtils.isBlank(password)) {
         jedis.auth(password);
+      }
+      if (dbindex > 0) {
+        jedis.select(dbindex);
       }
 
       jedis.connect();

--- a/src/main/resources/jenkins/plugins/logstash/configuration/Redis/configure-advanced.jelly
+++ b/src/main/resources/jenkins/plugins/logstash/configuration/Redis/configure-advanced.jelly
@@ -1,5 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="${%Dbindex}" field="dbindex">
+      <f:textbox default="${descriptor.defaultDbindex}"/>
+    </f:entry>
     <f:entry title="${%Password}" field="password">
       <f:password/>
     </f:entry>

--- a/src/main/resources/jenkins/plugins/logstash/configuration/Redis/help-dbindex.html
+++ b/src/main/resources/jenkins/plugins/logstash/configuration/Redis/help-dbindex.html
@@ -1,0 +1,4 @@
+<div>
+  The Redis database index to store data in.
+  </div>
+

--- a/src/test/java/jenkins/plugins/logstash/persistence/RedisDaoTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/RedisDaoTest.java
@@ -26,14 +26,14 @@ public class RedisDaoTest {
   @Mock JedisPool mockPool;
   @Mock Jedis mockJedis;
 
-  RedisDao createDao(String host, int port, String key, String username, String password) {
-    return new RedisDao(mockPool, host, port, key, password);
+  RedisDao createDao(String host, int port, String key, String username, String password, int dbindex) {
+    return new RedisDao(mockPool, host, port, key, password, dbindex);
   }
 
   @Before
   public void before() throws Exception {
     int port = (int) (Math.random() * 1000);
-    dao = createDao("localhost", port, "logstash", "username", "password");
+    dao = createDao("localhost", port, "logstash", "username", "password", 0);
 
     when(mockPool.getResource()).thenReturn(mockJedis);
   }
@@ -47,7 +47,7 @@ public class RedisDaoTest {
   @Test(expected = IllegalArgumentException.class)
   public void constructorFailNullHost() throws Exception {
     try {
-      createDao(null, 6379, "logstash", "username", "password");
+      createDao(null, 6379, "logstash", "username", "password", 0);
     } catch (IllegalArgumentException e) {
       assertEquals("Wrong error message was thrown", "host name is required", e.getMessage());
       throw e;
@@ -57,7 +57,7 @@ public class RedisDaoTest {
   @Test(expected = IllegalArgumentException.class)
   public void constructorFailEmptyHost() throws Exception {
     try {
-      createDao(" ", 6379, "logstash", "username", "password");
+      createDao(" ", 6379, "logstash", "username", "password", 0);
     } catch (IllegalArgumentException e) {
       assertEquals("Wrong error message was thrown", "host name is required", e.getMessage());
       throw e;
@@ -67,7 +67,7 @@ public class RedisDaoTest {
   @Test(expected = IllegalArgumentException.class)
   public void constructorFailNullKey() throws Exception {
     try {
-      createDao("localhost", 6379, null, "username", "password");
+      createDao("localhost", 6379, null, "username", "password", 0);
     } catch (IllegalArgumentException e) {
       assertEquals("Wrong error message was thrown", "redis key is required", e.getMessage());
       throw e;
@@ -77,7 +77,7 @@ public class RedisDaoTest {
   @Test(expected = IllegalArgumentException.class)
   public void constructorFailEmptyKey() throws Exception {
     try {
-      createDao("localhost", 6379, " ", "username", "password");
+      createDao("localhost", 6379, " ", "username", "password", 0);
     } catch (IllegalArgumentException e) {
       assertEquals("Wrong error message was thrown", "redis key is required", e.getMessage());
       throw e;
@@ -87,7 +87,7 @@ public class RedisDaoTest {
   @Test
   public void constructorSuccess() throws Exception {
     // Unit under test
-    dao = createDao("localhost", 6379, "logstash", "username", "password");
+    dao = createDao("localhost", 6379, "logstash", "username", "password", 0);
 
     // Verify results
     assertEquals("Wrong host name", "localhost", dao.getHost());
@@ -182,7 +182,7 @@ public class RedisDaoTest {
     String json = "{ 'foo': 'bar' }";
 
     // Initialize mocks
-    dao = createDao("localhost", 6379, "logstash", null, null);
+    dao = createDao("localhost", 6379, "logstash", null, null, 0);
     when(mockJedis.rpush("logstash", json)).thenReturn(1L);
 
     // Unit under test


### PR DESCRIPTION
This PR is a naive attempt at adding redis dbindex support. There is a new text field on the advanced config screen to enter the dbindex (defaults to 0) and if the dbindex is `> 0`. Jedis will call `.select(dbindex)` before trying to send data.

The changes did not break tests, and appear to work as expected on my install. Which is good? :-)

https://issues.jenkins.io/browse/JENKINS-65530

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
