### PR TITLE
Downgrade Mockito from 4.x to 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <skipIntegrationTests>true</skipIntegrationTests>
     <jenkins.version>2.249.1</jenkins.version>
     <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
+    <mockito.version>3.12.4</mockito.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
#112 was merged prematurely, before a passing CI build. That PR introduced a new test failure caused by the use of Mockito 4.x (from the latest plugin parent POM), which is incompatible with PowerMock. This PR resolves the issue by downgrading Mockito to 3.x, which is the latest version that works with PowerMock. I tested this locally and verified the issue was resolved. CC @jakub-bochenski