### PR TITLE
make the plugin see data stream last by adjusting decorator order, to…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.40</version>
+    <version>4.42</version>
   </parent>
 
   <artifactId>logstash</artifactId>
@@ -64,17 +64,18 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/logstash-plugin</gitHubRepo>
     <skipIntegrationTests>true</skipIntegrationTests>
-    <jenkins.version>2.249.1</jenkins.version>
+    <jenkins.version>2.346.1</jenkins.version>
     <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
     <mockito.version>3.12.4</mockito.version>
+    <useBeta>true</useBeta>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
-        <version>984.vb5eaac999a7e</version>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1478.v81d3dc4f9a_43</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
+++ b/src/main/java/jenkins/plugins/logstash/pipeline/GlobalDecorator.java
@@ -47,6 +47,14 @@ public class GlobalDecorator extends TaskListenerDecorator {
   public static final class Factory implements TaskListenerDecorator.Factory {
 
     @Override
+    /*
+      Data stream is passed to this decorator first (it actually sees data in the last)
+     */
+    public boolean isAppliedBeforeMainDecorator() {
+      return true;
+    }
+
+    @Override
     public TaskListenerDecorator of(FlowExecutionOwner owner) {
       if (!LogstashConfiguration.getInstance().isEnableGlobally()) {
         return null;


### PR DESCRIPTION
make the plugin see data stream last by adjusting decorator order, to avoid logging unmasked data
see also:
* https://github.com/jenkinsci/workflow-api-plugin/pull/166
* https://github.com/jenkinsci/splunk-devops-plugin/commit/1a10a537e88af0d7c2b63c2b96e800502bdc9442


<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
