### PR TITLE
require 2.332.4 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.40</version>
+    <version>4.46</version>
   </parent>
 
   <artifactId>logstash</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/logstash-plugin</gitHubRepo>
     <skipIntegrationTests>true</skipIntegrationTests>
-    <jenkins.version>2.249.1</jenkins.version>
+    <jenkins.version>2.332.4</jenkins.version>
     <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
     <mockito.version>3.12.4</mockito.version>
   </properties>
@@ -73,8 +73,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
-        <version>984.vb5eaac999a7e</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1595.v8c71c13cc3a_9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.332.4 or newer

Jenkins 2.332.x is used in over 2/3 of the logstash plugin installations.  That version is also the oldest LTS that does not have a security advisory.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
