### PR TITLE
Fix global instance singleton resolver

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashConfiguration.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
+import hudson.ExtensionList;
 import hudson.util.Secret;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -286,7 +287,7 @@ public class LogstashConfiguration extends GlobalConfiguration
 
   public static LogstashConfiguration getInstance()
   {
-    return GlobalConfiguration.all().get(LogstashConfiguration.class);
+    return ExtensionList.lookupSingleton(LogstashConfiguration.class);
   }
 
 }

--- a/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashIntegrationTest.java
@@ -12,8 +12,12 @@ import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import java.util.ArrayList;
 import java.util.List;
 
+import hudson.model.labels.LabelAtom;
 import org.jenkinsci.plugins.envinject.EnvInjectBuildWrapper;
 import org.jenkinsci.plugins.envinject.EnvInjectJobPropertyInfo;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,6 +66,8 @@ public class LogstashIntegrationTest
 
         slave = jenkins.createSlave();
         slave.setLabelString("myLabel");
+        jenkins.createOnlineSlave(new LabelAtom("test"));
+
         project = jenkins.createFreeStyleProject();
     }
 
@@ -219,6 +225,31 @@ public class LogstashIntegrationTest
       assertThat(data.getString("buildHost"),equalTo("Jenkins"));
       assertThat(data.getString("buildLabel"),equalTo("master"));
       assertThat(lastLine.getJSONArray("message").get(0).toString(),equalTo("Finished: SUCCESS"));
+    }
+
+    @Test
+    public void enableGloballyOnRemote() throws Exception
+    {
+        LogstashConfiguration.getInstance().setEnableGlobally(true);
+
+        WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "pipelineOnWorkerNode");
+        p.setDefinition(new CpsFlowDefinition("node('test') {echo 'foo'}\n", true));
+        WorkflowRun build = p.scheduleBuild2(0).get();
+
+        assertThat(build.getResult(), equalTo(Result.SUCCESS));
+        List<JSONObject> dataLines = memoryDao.getOutput();
+
+        assertThat(dataLines.size(), greaterThan(10));
+        boolean containsFoo = dataLines.stream()
+                .anyMatch(line -> line.getString("message").contains("foo"));
+        assertThat("Expected at least one line to contain 'foo'", containsFoo, is(true));
+        JSONObject firstLine = dataLines.get(0);
+        JSONObject lastLine = dataLines.get(dataLines.size()-1);
+        JSONObject data = firstLine.getJSONObject("data");
+
+        assertThat(data.getString("buildHost"),equalTo("Jenkins"));
+        assertThat(data.getString("buildLabel"),equalTo("master"));
+        assertThat(lastLine.getJSONArray("message").get(0).toString(),equalTo("Finished: SUCCESS"));
     }
 
     @Test


### PR DESCRIPTION
According to the [doc][1] to get an instance of a config we should use `ExtensionList.lookupSingleton(<your GlobalConfiguration subclass>.class)`

Initially started to check the code because we got exceptions on agents when using Git checkout:

```
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
	at jenkins.model.Jenkins.get(Jenkins.java:816)
	at jenkins.model.GlobalConfiguration.all(GlobalConfiguration.java:75)
	at jenkins.plugins.logstash.LogstashConfiguration.getInstance(LogstashConfiguration.java:289)
	at jenkins.plugins.logstash.LogstashWriter.getIndexerDao(LogstashWriter.java:162)
	at jenkins.plugins.logstash.LogstashWriter.getDaoOrNull(LogstashWriter.java:201)
	at jenkins.plugins.logstash.LogstashWriter.<init>(LogstashWriter.java:82)
	at jenkins.plugins.logstash.pipeline.GlobalDecorator.decorate(GlobalDecorator.java:41)
	at org.jenkinsci.plugins.workflow.log.TaskListenerDecorator.decorateAll(TaskListenerDecorator.java:230)
	at org.jenkinsci.plugins.workflow.log.TaskListenerDecorator$DecoratedTaskListener.getOutputStream(TaskListenerDecorator.java:267)
	at org.jenkinsci.plugins.workflow.log.OutputStreamTaskListener$Default.getLogger(OutputStreamTaskListener.java:116)
	at org.jenkinsci.plugins.workflow.log.TaskListenerDecorator$CloseableTaskListener.getLogger(TaskListenerDecorator.java:307)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2801)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2762)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2757)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:2051)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:2063)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.revParse(CliGitAPIImpl.java:1115)
	at hudson.plugins.git.GitAPI.revParse(GitAPI.java:419)
```

[1]: https://javadoc.jenkins-ci.org/jenkins/model/GlobalConfiguration.html

### Testing done

Added additional test to handle a remote logging from workflow pipeline job executed on agent.

Don't know how to test Git plugin within tests of this plugin.


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
