### PR TITLE
[JENKINS-66258] Retrieve non transient actions to prevent deadlock

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -276,7 +276,10 @@ public class BuildData implements Serializable {
         Result result = build.getResult();
         this.result = result == null ? null : result.toString();
       }
-      Action testResultAction = build.getAction(AbstractTestResultAction.class);
+      @SuppressWarnings("deprecation") // We don't need transient actions
+      Action testResultAction = build.getActions().stream()
+          .filter(action -> action instanceof AbstractTestResultAction).findFirst()
+          .orElse(null);
       if (testResults == null && testResultAction != null) {
         testResults = new TestData(testResultAction);
       }

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -116,7 +116,7 @@ public class LogstashWriterTest {
     when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
     when(mockBuild.getSensitiveBuildVariables()).thenReturn(Collections.emptySet());
     when(mockBuild.getEnvironments()).thenReturn(null);
-    when(mockBuild.getAction(AbstractTestResultAction.class)).thenReturn(mockTestResultAction);
+    when(mockBuild.getActions()).thenReturn(Collections.singletonList(mockTestResultAction));
     when(mockBuild.getLog(3)).thenReturn(Arrays.asList("line 1", "line 2", "line 3", "Log truncated..."));
     when(mockBuild.getEnvironment(null)).thenReturn(new EnvVars());
     when(mockBuild.getExecutor()).thenReturn(mockExecutor);
@@ -167,7 +167,7 @@ public class LogstashWriterTest {
     verify(mockBuild).getFullDisplayName();
     verify(mockBuild).getDescription();
     verify(mockBuild).getUrl();
-    verify(mockBuild).getAction(AbstractTestResultAction.class);
+    verify(mockBuild).getActions();
     verify(mockBuild).getExecutor();
     verify(mockBuild, times(2)).getNumber();
     verify(mockBuild).getTimestamp();

--- a/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
+++ b/src/test/java/jenkins/plugins/logstash/persistence/BuildDataTest.java
@@ -89,7 +89,7 @@ public class BuildDataTest {
     when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
     when(mockBuild.getSensitiveBuildVariables()).thenReturn(Collections.emptySet());
     when(mockBuild.getEnvironments()).thenReturn(null);
-    when(mockBuild.getAction(AbstractTestResultAction.class)).thenReturn(mockTestResultAction);
+    when(mockBuild.getActions()).thenReturn(Collections.singletonList(mockTestResultAction));
     when(mockBuild.getEnvironment(mockListener)).thenReturn(new EnvVars());
     when(mockBuild.getRootBuild()).thenReturn(mockRootBuild);
 
@@ -138,7 +138,7 @@ public class BuildDataTest {
     verify(mockBuild).getDescription();
     verify(mockBuild).getStartTimeInMillis();
     verify(mockBuild).getUrl();
-    verify(mockBuild).getAction(AbstractTestResultAction.class);
+    verify(mockBuild).getActions();
     verify(mockBuild).getExecutor();
     verify(mockBuild).getNumber();
     verify(mockBuild).getTimestamp();
@@ -264,7 +264,7 @@ public class BuildDataTest {
 
   @Test
   public void constructorSuccessNoTests() throws Exception {
-    when(mockBuild.getAction(AbstractTestResultAction.class)).thenReturn(null);
+    when(mockBuild.getActions()).thenReturn(Collections.emptyList());
 
     // Unit under test
     BuildData buildData = new BuildData(mockBuild, mockDate, mockListener);


### PR DESCRIPTION
[JENKINS-66258](https://issues.jenkins.io/browse/JENKINS-66258) do not lookup transient action factories for a `AbstractTestResultAction` to prevent deadlock through workflow-api. 

NOTE: As discussed in the issue, a further improvement of this plugin would be to handle work asynchronously from {{LogstashOutputStream.eol}}. What we ought to do here is a fix to prevent deadlocks int he meantime.

### Testing done

Run a simple pipeline with a junit step:

```
node {
    
    [...]
    
    sh "mvn clean install"
    
    junit(
        allowEmptyResults: true,
        testResults: '**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml'
    )
}
```

Validate in debug that the `TestResultAction` is retrieved with the proper details.
Validate in debug that the `LogstashOutputStream.eol` does not go through `TransientActionFactory#factoriesFor`

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue