### PR TITLE
Revert "Bump redis.clients:jedis from 2.6.0 to 5.1.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>5.1.0</version>
+      <version>2.6.0</version>
       <exclusions>
         <!-- Provided by Jenkins core -->
         <exclusion>


### PR DESCRIPTION
Reverts jenkinsci/logstash-plugin#143 - broke dependency convergence check, to be fixed later